### PR TITLE
249-fixed bug with notifications and setting button

### DIFF
--- a/app/components/ui/toast/CustomToast.tsx
+++ b/app/components/ui/toast/CustomToast.tsx
@@ -20,6 +20,7 @@ export interface CustomToasterProps {
 export const CustomToaster: React.FC<CustomToasterProps> = ({ position = 'top-right' }) => {
   return (
     <Toaster
+      style={{ width: 'fit-content' }}
       position={position}
       toastOptions={{
         unstyled: true,


### PR DESCRIPTION
Fixed bug when user cannot click on the setting button if notifications open

### ✅ Actual (PR)
![image](https://github.com/user-attachments/assets/937ad006-feee-48a7-82ab-e5e2d09121ae)

### ❌ Before (App)
![443835122-95fa052d-e6fb-4900-86df-7c5f058c6a2f](https://github.com/user-attachments/assets/63d38772-a498-495b-9e22-35705cbd39a7)
