### PR TITLE
ai models tabs are added

### DIFF
--- a/app/components/ai-services/AiServicesTabs.tsx
+++ b/app/components/ai-services/AiServicesTabs.tsx
@@ -1,0 +1,68 @@
+import { useNavigate, useSearchParams } from 'react-router';
+import { cn } from '~/utils/cn';
+
+type Tab = {
+  id: string;
+  label: string;
+  content: React.ReactNode;
+};
+
+type AiServicesTabsProps = {
+  tabs: Tab[];
+  defaultTab?: string;
+  filterComponent?: React.ReactNode;
+};
+
+export function AiServicesTabs({ tabs, defaultTab, filterComponent }: AiServicesTabsProps) {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  
+  // Read active tab from URL instead of local state
+  const activeTab = searchParams.get('tab') || defaultTab || tabs[0]?.id;
+
+  const handleTabClick = (tabId: string) => {
+    // Update URL with new tab while preserving other search params
+    const newSearchParams = new URLSearchParams(searchParams);
+    newSearchParams.set('tab', tabId);
+    navigate(`/services/ai?${newSearchParams.toString()}`, { replace: true });
+  };
+
+  const activeTabContent = tabs.find(tab => tab.id === activeTab)?.content;
+
+  return (
+    <div className='w-full'>
+      {/* Tab Navigation */}
+      <div className='border-b border-neutral-04 mb-6'>
+        <div className='flex justify-between items-center'>
+          <div className='flex space-x-8'>
+            {tabs.map((tab) => (
+              <button
+                key={tab.id}
+                onClick={() => handleTabClick(tab.id)}
+                className={cn(
+                  'py-3 px-1 text-sm font-medium border-b-2 transition-colors relative',
+                  activeTab === tab.id
+                    ? 'border-primary text-primary'
+                    : 'border-transparent text-neutral-01 hover:text-base-black hover:border-neutral-03'
+                )}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
+          {/* Filter Component on the right */}
+          {filterComponent && (
+            <div className='flex items-center'>
+              {filterComponent}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Tab Content */}
+      <div className='w-full'>
+        {activeTabContent}
+      </div>
+    </div>
+  );
+}

--- a/app/components/ai-services/ChatModelsTab.tsx
+++ b/app/components/ai-services/ChatModelsTab.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router';
+import * as Accordion from '@radix-ui/react-accordion';
+import type { ChatModelsPaginated } from '~/types';
+import { fetchPaginatedData } from '~/utils/fetchWithAuth';
+import SearchChatModels from '~/components/ui/search-chat-models';
+import { useInfiniteScroll } from '~/hooks/useInfiniteScroll';
+import { Icons } from '~/components/ui/icons';
+import { ChatModelItem } from '~/components/chat-models/ChatModelItem';
+import { ChatModelSkeleton } from '~/components/chat-models/ChatModelSkeleton';
+
+type ChatModelsTabProps = {
+  initialData: ChatModelsPaginated | null;
+};
+
+export function ChatModelsTab({ initialData }: ChatModelsTabProps) {
+  const [searchParams] = useSearchParams();
+  const [hasInitiallyLoaded, setHasInitiallyLoaded] = useState(false);
+
+  // Initialize loaded state
+  useEffect(() => {
+    if (initialData) {
+      const timer = setTimeout(() => {
+        setHasInitiallyLoaded(true);
+      }, 500);
+      return () => clearTimeout(timer);
+    }
+  }, [initialData]);
+
+  const fetchMoreWithParams = async (page: number) => {
+    return fetchPaginatedData<ChatModelsPaginated>('chat-models', searchParams, page, 10);
+  };
+
+  const infiniteScrollData = useMemo(() => initialData?.data || [], [initialData?.data]);
+  const infiniteScrollMeta = useMemo(() => 
+    initialData?.meta || { total: 0, page: 1, limit: 10, totalPages: 1 }, 
+    [initialData?.meta]
+  );
+
+  const infiniteScroll = useInfiniteScroll({
+    initialData: infiniteScrollData,
+    initialMeta: infiniteScrollMeta,
+    fetchMore: fetchMoreWithParams,
+    enabled: hasInitiallyLoaded && !!initialData,
+  });
+
+  const filteredChatModels = useMemo(() => {
+    return [...infiniteScroll.data];
+  }, [infiniteScroll.data]);
+
+  if (!hasInitiallyLoaded || !initialData) {
+    return <ChatModelSkeleton />;
+  }
+
+  return (
+    <div className='w-full'>
+      {/* Search Section */}
+      <div className='mb-6'>
+        <SearchChatModels />
+      </div>
+
+      {/* Results Section */}
+      <div className='pb-5'>
+        {filteredChatModels.length === 0 ? (
+          <p className='text-body-md text-neutral-01 text-center'>No chat models found.</p>
+        ) : (
+          <Accordion.Root type='multiple' className='space-y-3'>
+            {filteredChatModels.map((chatModel) => (
+              <ChatModelItem key={chatModel.id} chatModel={chatModel} />
+            ))}
+          </Accordion.Root>
+        )}
+
+        {infiniteScroll.error && (
+          <div className='text-center text-red-500 py-4'>
+            <p>Failed to load chat models: {infiniteScroll.error}</p>
+          </div>
+        )}
+
+        {infiniteScroll.loading && (
+          <div className='text-center py-4'>
+            <div className='inline-flex items-center gap-2'>
+              <Icons.loading className='size-4 animate-spin' />
+              <span className='text-neutral-01'>Loading more chat models...</span>
+            </div>
+          </div>
+        )}
+
+        {infiniteScroll.hasMore && !infiniteScroll.loading && <div ref={infiniteScroll.triggerRef} className='h-4' />}
+      </div>
+    </div>
+  );
+}

--- a/app/components/ai-services/EmbeddingModelsTab.tsx
+++ b/app/components/ai-services/EmbeddingModelsTab.tsx
@@ -1,0 +1,247 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router';
+import * as Accordion from '@radix-ui/react-accordion';
+import type { EmbeddingModel } from '~/types';
+import { fetchPaginatedData } from '~/utils/fetchWithAuth';
+import { useInfiniteScroll } from '~/hooks/useInfiniteScroll';
+import { Icons } from '~/components/ui/icons';
+import { formatModelName } from '~/utils/formatModelName';
+import { scientificNumConvert } from '~/utils/scientificNumConvert';
+import { RecommendedBadge } from '~/components/ui/RecommendedBadge';
+import { getPicture } from '~/utils/getPicture';
+import * as Button from '~/components/ui/button/button';
+import Tooltip from '~/components/ui/tooltip';
+
+type EmbeddingModelsPaginated = {
+  data: EmbeddingModel[];
+  meta: {
+    total: number;
+    page: number;
+    limit: number;
+    totalPages: number;
+  };
+};
+
+function EmbeddingModelSkeleton() {
+  return (
+    <div className='space-y-3'>
+      {Array.from({ length: 3 }).map((_, i) => (
+        <div key={i} className='bg-white rounded-xl shadow-bottom-level-1 overflow-hidden'>
+          <div className='p-5'>
+            <div className='flex items-center gap-3 flex-1'>
+              {/* Provider Icon Skeleton */}
+              <div className='size-8 bg-gradient-1 rounded-lg animate-pulse flex-shrink-0'></div>
+              
+              {/* Model Info Skeleton */}
+              <div className='flex flex-col flex-1 min-w-0 gap-1'>
+                <div className='h-5 bg-gradient-1 rounded w-48 animate-pulse'></div>
+                <div className='h-4 bg-gradient-1 rounded w-24 animate-pulse'></div>
+              </div>
+              
+              {/* Quick Stats Skeleton */}
+              <div className='hidden sm:flex items-center gap-6'>
+                <div className='text-center space-y-1'>
+                  <div className='h-4 bg-gradient-1 rounded w-12 animate-pulse'></div>
+                  <div className='h-3 bg-gradient-1 rounded w-8 animate-pulse'></div>
+                </div>
+                <div className='text-center space-y-1'>
+                  <div className='h-4 bg-gradient-1 rounded w-12 animate-pulse'></div>
+                  <div className='h-3 bg-gradient-1 rounded w-8 animate-pulse'></div>
+                </div>
+              </div>
+              
+              {/* Chevron Skeleton */}
+              <div className='size-5 bg-gradient-1 rounded animate-pulse flex-shrink-0 ml-2'></div>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function EmbeddingModelItem({ embeddingModel }: { embeddingModel: EmbeddingModel }) {
+  return (
+    <Accordion.Item
+      value={embeddingModel.id}
+      className='bg-white rounded-xl shadow-bottom-level-1 overflow-hidden'
+    >
+      <div className='relative'>
+        <Accordion.Trigger className='group flex w-full items-center justify-between p-5 text-left hover:bg-neutral-05 transition-colors'>
+          <div className='flex items-center gap-3 flex-1'>
+            {/* Provider Icon */}
+            {embeddingModel.aiProvider && (
+              <div className='size-8 flex-shrink-0'>
+                <img
+                  src={getPicture(embeddingModel.aiProvider, 'ai-providers', false)}
+                  alt={embeddingModel.aiProvider.name}
+                  className='size-full object-cover rounded-lg'
+                  loading='lazy'
+                />
+              </div>
+            )}
+
+            {/* Model Info */}
+            <div className='flex flex-col flex-1 min-w-0'>
+              <div className='flex items-center gap-2 mb-1'>
+                {embeddingModel.error && (
+                  <Tooltip
+                    side={'top'}
+                    trigger={<Icons.warning className='size-4 text-specials-danger flex-shrink-0' />}
+                    content={embeddingModel.error}
+                    popoverClassName='max-w-[350px]'
+                  />
+                )}
+                <span className='font-semibold text-lg text-base-black truncate'>{formatModelName(embeddingModel.providerModelName)}</span>
+                <RecommendedBadge recommended={embeddingModel.recommended} tooltipText='Recommended' />
+              </div>
+
+              {embeddingModel.aiProvider && <span className='text-sm text-neutral-01'>{embeddingModel.aiProvider.name}</span>}
+            </div>
+
+            {/* Quick Stats */}
+            <div className='hidden sm:flex items-center gap-6 text-sm text-neutral-01'>
+              <div className='text-center'>
+                <div className='font-medium text-base-black'>${scientificNumConvert(embeddingModel.dollarPerInputToken * 1000000)}</div>
+                <div>Input</div>
+              </div>
+              <div className='text-center'>
+                <div className='font-medium text-base-black'>${scientificNumConvert(embeddingModel.dollarPerOutputToken * 1000000)}</div>
+                <div>Output</div>
+              </div>
+            </div>
+          </div>
+
+          <Icons.chevronDown className='size-5 text-neutral-01 transition-transform duration-200 group-data-[state=open]:rotate-180 ml-2 flex-shrink-0' />
+        </Accordion.Trigger>
+      </div>
+      
+      <Accordion.Content className='overflow-hidden data-[state=open]:animate-accordion-down data-[state=closed]:animate-accordion-up'>
+        <div className='px-5 pb-5'>
+          <div className='grid grid-cols-1 sm:grid-cols-2 gap-4 pt-4 border-t border-neutral-04'>
+            <div className='space-y-1'>
+              <label className='text-sm font-medium text-neutral-01'>Input Cost</label>
+              <div className='text-base font-semibold text-base-black'>
+                ${scientificNumConvert(embeddingModel.dollarPerInputToken * 1000000)}/1M tokens
+              </div>
+            </div>
+
+            <div className='space-y-1'>
+              <label className='text-sm font-medium text-neutral-01'>Output Cost</label>
+              <div className='text-base font-semibold text-base-black'>
+                ${scientificNumConvert(embeddingModel.dollarPerOutputToken * 1000000)}/1M tokens
+              </div>
+            </div>
+
+            {embeddingModel.info && (
+              <div className='space-y-1 sm:col-span-2'>
+                <label className='text-sm font-medium text-neutral-01'>Additional Info</label>
+                <div className='text-sm text-base-black bg-neutral-05 p-3 rounded-lg'>{embeddingModel.info}</div>
+              </div>
+            )}
+
+            <div className='space-y-1 sm:col-span-2'>
+              <label className='text-sm font-medium text-neutral-01'>Features</label>
+              <div className='flex flex-wrap gap-2'>
+                {embeddingModel.recommended && (
+                  <span className='px-2 py-1 bg-gradient-1 text-base-black text-xs font-medium rounded-full'>Recommended</span>
+                )}
+              </div>
+            </div>
+
+            {/* Actions */}
+            <div className='sm:col-span-2 pt-4 border-t border-neutral-04'>
+              <div className='flex gap-3'>
+                <Button.Root variant='primary' size='sm' className='px-4'>
+                  Edit
+                </Button.Root>
+                <Button.Root variant='danger' size='sm' className='px-4'>
+                  <Button.Icon as={Icons.trash} />
+                  Delete
+                </Button.Root>
+              </div>
+            </div>
+          </div>
+        </div>
+      </Accordion.Content>
+    </Accordion.Item>
+  );
+}
+
+type EmbeddingModelsTabProps = {
+  initialData: EmbeddingModelsPaginated | null;
+};
+
+export function EmbeddingModelsTab({ initialData }: EmbeddingModelsTabProps) {
+  const [searchParams] = useSearchParams();
+  const [hasInitiallyLoaded, setHasInitiallyLoaded] = useState(false);
+
+  // Initialize loaded state
+  useEffect(() => {
+    if (initialData) {
+      const timer = setTimeout(() => {
+        setHasInitiallyLoaded(true);
+      }, 500);
+      return () => clearTimeout(timer);
+    }
+  }, [initialData]);
+
+  const infiniteScrollData = useMemo(() => initialData?.data || [], [initialData?.data]);
+  const infiniteScrollMeta = useMemo(() => 
+    initialData?.meta || { total: 0, page: 1, limit: 10, totalPages: 1 }, 
+    [initialData?.meta]
+  );
+
+  const fetchMoreWithParams = async (page: number) => {
+    return fetchPaginatedData<EmbeddingModelsPaginated>('embedding-models', searchParams, page, 10);
+  };
+
+  const infiniteScroll = useInfiniteScroll({
+    initialData: infiniteScrollData,
+    initialMeta: infiniteScrollMeta,
+    fetchMore: fetchMoreWithParams,
+    enabled: hasInitiallyLoaded && !!initialData && infiniteScrollMeta.totalPages > 1,
+  });
+
+  const filteredEmbeddingModels = useMemo(() => {
+    return [...infiniteScroll.data];
+  }, [infiniteScroll.data]);
+
+  if (!hasInitiallyLoaded || !initialData) {
+    return <EmbeddingModelSkeleton />;
+  }
+
+  return (
+    <div className='w-full'>
+      {/* Results Section */}
+      <div className='pb-5'>
+        {filteredEmbeddingModels.length === 0 ? (
+          <p className='text-body-md text-neutral-01 text-center'>No embedding models found.</p>
+        ) : (
+          <Accordion.Root type='multiple' className='space-y-3'>
+            {filteredEmbeddingModels.map((embeddingModel) => (
+              <EmbeddingModelItem key={embeddingModel.id} embeddingModel={embeddingModel} />
+            ))}
+          </Accordion.Root>
+        )}
+
+        {infiniteScroll.error && (
+          <div className='text-center text-red-500 py-4'>
+            <p>Failed to load embedding models: {infiniteScroll.error}</p>
+          </div>
+        )}
+
+        {infiniteScroll.loading && (
+          <div className='text-center py-4'>
+            <div className='inline-flex items-center gap-2'>
+              <Icons.loading className='size-4 animate-spin' />
+              <span className='text-neutral-01'>Loading more embedding models...</span>
+            </div>
+          </div>
+        )}
+
+        {infiniteScroll.hasMore && !infiniteScroll.loading && <div ref={infiniteScroll.triggerRef} className='h-4' />}
+      </div>
+    </div>
+  );
+}

--- a/app/components/ai-services/ModelTabs.tsx
+++ b/app/components/ai-services/ModelTabs.tsx
@@ -1,0 +1,48 @@
+import type { ChatModel, EmbeddingModel, ChatModelsPaginated, meta } from '~/types';
+import { ChatModelsTab } from './ChatModelsTab';
+import { EmbeddingModelsTab } from './EmbeddingModelsTab';
+import { ReasoningModelsTab } from './ReasoningModelsTab';
+
+type EmbeddingModelsPaginated = {
+  data: EmbeddingModel[];
+  meta: meta;
+};
+
+type ReasoningModelsPaginated = {
+  data: ChatModel[];
+  meta: meta;
+};
+
+type ModelTabsProps = {
+  chatModelsPaginated: ChatModelsPaginated | null;
+  embeddingModelsPaginated: EmbeddingModelsPaginated | null;
+  reasoningModelsPaginated: ReasoningModelsPaginated | null;
+};
+
+export function ModelTabs({ 
+  chatModelsPaginated, 
+  embeddingModelsPaginated, 
+  reasoningModelsPaginated 
+}: ModelTabsProps) {
+  const tabs = [
+    {
+      id: 'chat-models',
+      label: 'Chat Models',
+      content: <ChatModelsTab initialData={chatModelsPaginated} />,
+    },
+    {
+      id: 'embedding-models',
+      label: 'Embedding Models',
+      content: <EmbeddingModelsTab initialData={embeddingModelsPaginated} />,
+    },
+    {
+      id: 'reasoning-models',
+      label: 'Reasoning Models',
+      content: <ReasoningModelsTab initialData={reasoningModelsPaginated} />,
+    },
+  ];
+
+  return tabs;
+}
+
+export type { EmbeddingModelsPaginated, ReasoningModelsPaginated };

--- a/app/components/ai-services/ReasoningModelsTab.tsx
+++ b/app/components/ai-services/ReasoningModelsTab.tsx
@@ -1,0 +1,271 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router';
+import * as Accordion from '@radix-ui/react-accordion';
+import type { ChatModel } from '~/types';
+import { fetchPaginatedData } from '~/utils/fetchWithAuth';
+import { useInfiniteScroll } from '~/hooks/useInfiniteScroll';
+import { Icons } from '~/components/ui/icons';
+import { formatModelName } from '~/utils/formatModelName';
+import { scientificNumConvert } from '~/utils/scientificNumConvert';
+import { RecommendedBadge } from '~/components/ui/RecommendedBadge';
+import { getPicture } from '~/utils/getPicture';
+import * as Button from '~/components/ui/button/button';
+import Tooltip from '~/components/ui/tooltip';
+
+type ReasoningModelsPaginated = {
+  data: ChatModel[];
+  meta: {
+    total: number;
+    page: number;
+    limit: number;
+    totalPages: number;
+  };
+};
+
+function ReasoningModelSkeleton() {
+  return (
+    <div className='space-y-3'>
+      {Array.from({ length: 3 }).map((_, i) => (
+        <div key={i} className='bg-white rounded-xl shadow-bottom-level-1 overflow-hidden'>
+          <div className='p-5'>
+            <div className='flex items-center gap-3 flex-1'>
+              {/* Provider Icon Skeleton */}
+              <div className='size-8 bg-gradient-1 rounded-lg animate-pulse flex-shrink-0'></div>
+              
+              {/* Model Info Skeleton */}
+              <div className='flex flex-col flex-1 min-w-0 gap-1'>
+                <div className='h-5 bg-gradient-1 rounded w-48 animate-pulse'></div>
+                <div className='h-4 bg-gradient-1 rounded w-24 animate-pulse'></div>
+              </div>
+              
+              {/* Quick Stats Skeleton */}
+              <div className='hidden sm:flex items-center gap-6'>
+                <div className='text-center space-y-1'>
+                  <div className='h-4 bg-gradient-1 rounded w-16 animate-pulse'></div>
+                  <div className='h-3 bg-gradient-1 rounded w-12 animate-pulse'></div>
+                </div>
+                <div className='text-center space-y-1'>
+                  <div className='h-4 bg-gradient-1 rounded w-12 animate-pulse'></div>
+                  <div className='h-3 bg-gradient-1 rounded w-8 animate-pulse'></div>
+                </div>
+                <div className='text-center space-y-1'>
+                  <div className='h-4 bg-gradient-1 rounded w-12 animate-pulse'></div>
+                  <div className='h-3 bg-gradient-1 rounded w-8 animate-pulse'></div>
+                </div>
+              </div>
+              
+              {/* Chevron Skeleton */}
+              <div className='size-5 bg-gradient-1 rounded animate-pulse flex-shrink-0 ml-2'></div>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ReasoningModelItem({ reasoningModel }: { reasoningModel: ChatModel }) {
+  return (
+    <Accordion.Item
+      value={reasoningModel.id}
+      className='bg-white rounded-xl shadow-bottom-level-1 overflow-hidden'
+    >
+      <div className='relative'>
+        <Accordion.Trigger className='group flex w-full items-center justify-between p-5 text-left hover:bg-neutral-05 transition-colors'>
+          <div className='flex items-center gap-3 flex-1'>
+            {/* Provider Icon */}
+            {reasoningModel.aiProvider && (
+              <div className='size-8 flex-shrink-0'>
+                <img
+                  src={getPicture(reasoningModel.aiProvider, 'ai-providers', false)}
+                  alt={reasoningModel.aiProvider.name}
+                  className='size-full object-cover rounded-lg'
+                  loading='lazy'
+                />
+              </div>
+            )}
+
+            {/* Model Info */}
+            <div className='flex flex-col flex-1 min-w-0'>
+              <div className='flex items-center gap-2 mb-1'>
+                {reasoningModel.error && (
+                  <Tooltip
+                    side={'top'}
+                    trigger={<Icons.warning className='size-4 text-specials-danger flex-shrink-0' />}
+                    content={reasoningModel.error}
+                    popoverClassName='max-w-[350px]'
+                  />
+                )}
+                <span className='font-semibold text-lg text-base-black truncate'>{formatModelName(reasoningModel.providerModelName)}</span>
+                <RecommendedBadge recommended={reasoningModel.recommended} tooltipText='Recommended' />
+              </div>
+
+              {reasoningModel.aiProvider && <span className='text-sm text-neutral-01'>{reasoningModel.aiProvider.name}</span>}
+            </div>
+
+            {/* Quick Stats */}
+            <div className='hidden sm:flex items-center gap-6 text-sm text-neutral-01'>
+              <div className='text-center'>
+                <div className='font-medium text-base-black'>{reasoningModel.contextWindow?.toLocaleString() || 'N/A'}</div>
+                <div>Context</div>
+              </div>
+              <div className='text-center'>
+                <div className='font-medium text-base-black'>${scientificNumConvert(reasoningModel.dollarPerInputToken * 1000000)}</div>
+                <div>Input</div>
+              </div>
+              <div className='text-center'>
+                <div className='font-medium text-base-black'>${scientificNumConvert(reasoningModel.dollarPerOutputToken * 1000000)}</div>
+                <div>Output</div>
+              </div>
+            </div>
+          </div>
+
+          <Icons.chevronDown className='size-5 text-neutral-01 transition-transform duration-200 group-data-[state=open]:rotate-180 ml-2 flex-shrink-0' />
+        </Accordion.Trigger>
+      </div>
+      
+      <Accordion.Content className='overflow-hidden data-[state=open]:animate-accordion-down data-[state=closed]:animate-accordion-up'>
+        <div className='px-5 pb-5'>
+          <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 pt-4 border-t border-neutral-04'>
+            <div className='space-y-1'>
+              <label className='text-sm font-medium text-neutral-01'>Context Window</label>
+              <div className='text-base font-semibold text-base-black'>{reasoningModel.contextWindow?.toLocaleString() || 'N/A'} tokens</div>
+            </div>
+
+            <div className='space-y-1'>
+              <label className='text-sm font-medium text-neutral-01'>Input Cost</label>
+              <div className='text-base font-semibold text-base-black'>
+                ${scientificNumConvert(reasoningModel.dollarPerInputToken * 1000000)}/1M tokens
+              </div>
+            </div>
+
+            <div className='space-y-1'>
+              <label className='text-sm font-medium text-neutral-01'>Output Cost</label>
+              <div className='text-base font-semibold text-base-black'>
+                ${scientificNumConvert(reasoningModel.dollarPerOutputToken * 1000000)}/1M tokens
+              </div>
+            </div>
+
+            <div className='space-y-1'>
+              <label className='text-sm font-medium text-neutral-01'>Average Response Time</label>
+              <div className='text-base font-semibold text-base-black'>{reasoningModel.aggregateChatCompletions?.avgTimeTakenMs || '--'} ms</div>
+            </div>
+
+            {reasoningModel.info && (
+              <div className='space-y-1 sm:col-span-2 lg:col-span-4'>
+                <label className='text-sm font-medium text-neutral-01'>Additional Info</label>
+                <div className='text-sm text-base-black bg-neutral-05 p-3 rounded-lg'>{reasoningModel.info}</div>
+              </div>
+            )}
+
+            <div className='space-y-1 sm:col-span-2 lg:col-span-4'>
+              <label className='text-sm font-medium text-neutral-01'>Features</label>
+              <div className='flex flex-wrap gap-2'>
+                {reasoningModel.recommended && (
+                  <span className='px-2 py-1 bg-gradient-1 text-base-black text-xs font-medium rounded-full'>Recommended</span>
+                )}
+                {reasoningModel.censored && (
+                  <span className='px-2 py-1 bg-neutral-04 text-neutral-01 text-xs font-medium rounded-full'>Censored</span>
+                )}
+                {!reasoningModel.censored && (
+                  <span className='px-2 py-1 bg-green-100 text-green-700 text-xs font-medium rounded-full'>Uncensored</span>
+                )}
+              </div>
+            </div>
+
+            {/* Actions */}
+            <div className='sm:col-span-2 lg:col-span-4 pt-4 border-t border-neutral-04'>
+              <div className='flex gap-3'>
+                <Button.Root variant='primary' size='sm' className='px-4'>
+                  Edit
+                </Button.Root>
+                <Button.Root variant='danger' size='sm' className='px-4'>
+                  <Button.Icon as={Icons.trash} />
+                  Delete
+                </Button.Root>
+              </div>
+            </div>
+          </div>
+        </div>
+      </Accordion.Content>
+    </Accordion.Item>
+  );
+}
+
+type ReasoningModelsTabProps = {
+  initialData: ReasoningModelsPaginated | null;
+};
+
+export function ReasoningModelsTab({ initialData }: ReasoningModelsTabProps) {
+  const [searchParams] = useSearchParams();
+  const [hasInitiallyLoaded, setHasInitiallyLoaded] = useState(false);
+
+  // Initialize loaded state
+  useEffect(() => {
+    if (initialData) {
+      const timer = setTimeout(() => {
+        setHasInitiallyLoaded(true);
+      }, 500);
+      return () => clearTimeout(timer);
+    }
+  }, [initialData]);
+
+  const infiniteScrollData = useMemo(() => initialData?.data || [], [initialData?.data]);
+  const infiniteScrollMeta = useMemo(() => 
+    initialData?.meta || { total: 0, page: 1, limit: 10, totalPages: 1 }, 
+    [initialData?.meta]
+  );
+
+  const fetchMoreWithParams = async (page: number) => {
+    return fetchPaginatedData<ReasoningModelsPaginated>('reasoning-models', searchParams, page, 10);
+  };
+
+  const infiniteScroll = useInfiniteScroll({
+    initialData: infiniteScrollData,
+    initialMeta: infiniteScrollMeta,
+    fetchMore: fetchMoreWithParams,
+    enabled: hasInitiallyLoaded && !!initialData && infiniteScrollMeta.totalPages > 1,
+  });
+
+  const filteredReasoningModels = useMemo(() => {
+    return [...infiniteScroll.data];
+  }, [infiniteScroll.data]);
+
+  if (!hasInitiallyLoaded || !initialData) {
+    return <ReasoningModelSkeleton />;
+  }
+
+  return (
+    <div className='w-full'>
+      {/* Results Section */}
+      <div className='pb-5'>
+        {filteredReasoningModels.length === 0 ? (
+          <p className='text-body-md text-neutral-01 text-center'>No reasoning models found.</p>
+        ) : (
+          <Accordion.Root type='multiple' className='space-y-3'>
+            {filteredReasoningModels.map((reasoningModel) => (
+              <ReasoningModelItem key={reasoningModel.id} reasoningModel={reasoningModel} />
+            ))}
+          </Accordion.Root>
+        )}
+
+        {infiniteScroll.error && (
+          <div className='text-center text-red-500 py-4'>
+            <p>Failed to load reasoning models: {infiniteScroll.error}</p>
+          </div>
+        )}
+
+        {infiniteScroll.loading && (
+          <div className='text-center py-4'>
+            <div className='inline-flex items-center gap-2'>
+              <Icons.loading className='size-4 animate-spin' />
+              <span className='text-neutral-01'>Loading more reasoning models...</span>
+            </div>
+          </div>
+        )}
+
+        {infiniteScroll.hasMore && !infiniteScroll.loading && <div ref={infiniteScroll.triggerRef} className='h-4' />}
+      </div>
+    </div>
+  );
+}

--- a/app/components/ai-services/TableDefinitions.tsx
+++ b/app/components/ai-services/TableDefinitions.tsx
@@ -1,0 +1,191 @@
+import type { ChatModel, EmbeddingModel } from '~/types';
+import type { TTableColumn } from '~/components/Table';
+import { scientificNumConvert } from '~/utils/scientificNumConvert';
+import { formatModelName } from '~/utils/formatModelName';
+import { RecommendedBadge } from '~/components/ui/RecommendedBadge';
+import { ViewButton } from '~/components/preferencesViewButton';
+import { Icons } from '~/components/ui/icons';
+import Tooltip from '~/components/ui/tooltip';
+
+export const chatModelColumns: Array<TTableColumn<ChatModel>> = [
+  {
+    id: 'providerModelName',
+    label: 'Chat model',
+    render: (data) => (
+      <span className='font-semibold text-body-md flex items-center gap-2'>
+        {data.error && (
+          <Tooltip
+            side={'top'}
+            trigger={<Icons.warning className='size-4 text-specials-danger' />}
+            content={data.error}
+            popoverClassName='max-w-[350px]'
+          />
+        )}
+        {formatModelName(data.providerModelName)}
+        <RecommendedBadge recommended={data.recommended} tooltipText='Recommended' />
+      </span>
+    ),
+    align: 'left',
+    className: 'min-w-[220px] max-w-[280px]',
+  },
+  {
+    id: 'aiProviderId',
+    label: '',
+    render: (data) => <span className='text-body-sm text-neutral-01'>{data.info}</span>,
+    align: 'left',
+  },
+  {
+    id: 'dollarPerInputToken',
+    label: 'Input',
+    render: (data) => <span className='text-sm'>${scientificNumConvert(data.dollarPerInputToken * 1000000)}</span>,
+    align: 'right',
+    width: '104px',
+    tooltipText: 'The cost of processing one million tokens that you send to the model',
+  },
+  {
+    id: 'dollarPerOutputToken',
+    label: 'Output',
+    render: (data) => <span className='text-sm'>${scientificNumConvert(data.dollarPerOutputToken * 1000000)}</span>,
+    align: 'right',
+    width: '104px',
+    tooltipText: 'Cost 1 unit of the token you received at the same rate',
+  },
+  {
+    id: 'id',
+    label: '',
+    render: (data) => (
+      <ViewButton
+        popoverItems={[
+          { text: 'Edit', href: `/services/ai/chat-models/${data.id}/edit` },
+          { text: 'Delete', href: `/services/ai/chat-models/${data.id}/delete`, isDelete: true },
+        ]}
+        className='flex items-center justify-center'
+        isDataCard={true}
+      />
+    ),
+    width: '44px',
+    align: 'right',
+  },
+];
+
+export const embeddingModelColumns: Array<TTableColumn<EmbeddingModel>> = [
+  {
+    id: 'providerModelName',
+    label: 'Embedding model',
+    render: (data) => (
+      <span className='font-semibold text-body-md flex items-center gap-2'>
+        {data.error && (
+          <Tooltip
+            side={'top'}
+            trigger={<Icons.warning className='size-4 text-specials-danger' />}
+            content={data.error}
+            className='max-w-[350px]'
+          />
+        )}
+        {formatModelName(data.providerModelName)}
+        <RecommendedBadge recommended={data.recommended} tooltipText='Recommended' />
+      </span>
+    ),
+    align: 'left',
+    className: 'min-w-[220px] max-w-[280px]',
+  },
+  {
+    id: 'aiProviderId',
+    label: '',
+    render: (data) => <span className='text-body-sm text-neutral-01'>{data.info}</span>,
+    align: 'left',
+  },
+  {
+    id: 'dollarPerInputToken',
+    label: 'Input',
+    render: (data) => <span className='text-sm'>${scientificNumConvert(data.dollarPerInputToken * 1000000)}</span>,
+    align: 'right',
+    width: '104px',
+    tooltipText: 'The cost of processing one million tokens that you send to the model',
+  },
+  {
+    id: 'dollarPerOutputToken',
+    label: 'Output',
+    render: (data) => <span className='text-sm'>${scientificNumConvert(data.dollarPerOutputToken * 1000000)}</span>,
+    align: 'right',
+    width: '104px',
+    tooltipText: 'Cost 1 unit of the token you received at the same rate',
+  },
+  {
+    id: 'id',
+    label: '',
+    render: (data) => (
+      <ViewButton
+        popoverItems={[
+          { text: 'Edit', href: `/services/ai/embedding-models/${data.id}/edit` },
+          { text: 'Delete', href: `/services/ai/embedding-models/${data.id}/delete`, isDelete: true },
+        ]}
+        className='flex items-center justify-center'
+        isDataCard={true}
+      />
+    ),
+    width: '44px',
+    align: 'right',
+  },
+];
+
+export const reasoningModelColumns: Array<TTableColumn<ChatModel>> = [
+  {
+    id: 'providerModelName',
+    label: 'Reasoning model',
+    render: (data) => (
+      <span className='font-semibold text-body-md flex items-center gap-2'>
+        {data.error && (
+          <Tooltip
+            side={'top'}
+            trigger={<Icons.warning className='size-4 text-specials-danger' />}
+            content={data.error}
+            className='max-w-[350px]'
+          />
+        )}
+        {formatModelName(data.providerModelName)}
+        <RecommendedBadge recommended={data.recommended} tooltipText='Recommended' />
+      </span>
+    ),
+    align: 'left',
+    className: 'min-w-[220px] max-w-[280px]',
+  },
+  {
+    id: 'aiProviderId',
+    label: '',
+    render: (data) => <span className='text-body-sm text-neutral-01'>{data.info}</span>,
+    align: 'left',
+  },
+  {
+    id: 'dollarPerInputToken',
+    label: 'Input',
+    render: (data) => <span className='text-sm'>${scientificNumConvert(data.dollarPerInputToken * 1000000)}</span>,
+    align: 'right',
+    width: '104px',
+    tooltipText: 'The cost of processing one million tokens that you send to the model',
+  },
+  {
+    id: 'dollarPerOutputToken',
+    label: 'Output',
+    render: (data) => <span className='text-sm'>${scientificNumConvert(data.dollarPerOutputToken * 1000000)}</span>,
+    align: 'right',
+    width: '104px',
+    tooltipText: 'Cost 1 unit of the token you received at the same rate',
+  },
+  {
+    id: 'id',
+    label: '',
+    render: (data) => (
+      <ViewButton
+        popoverItems={[
+          { text: 'Edit', href: `/services/ai/reasoning-models/${data.id}/edit` },
+          { text: 'Delete', href: `/services/ai/reasoning-models/${data.id}/delete`, isDelete: true },
+        ]}
+        className='flex items-center justify-center'
+        isDataCard={true}
+      />
+    ),
+    width: '44px',
+    align: 'right',
+  },
+];

--- a/app/components/chat-models/ChatModelItem.tsx
+++ b/app/components/chat-models/ChatModelItem.tsx
@@ -1,0 +1,163 @@
+import { Link, useRouteLoaderData } from 'react-router';
+import * as Accordion from '@radix-ui/react-accordion';
+import * as Button from '~/components/ui/button/button';
+import { scientificNumConvert } from '~/utils/scientificNumConvert';
+import { getPicture } from '~/utils/getPicture';
+import { RecommendedBadge } from '~/components/ui/RecommendedBadge';
+import { formatModelName } from '~/utils/formatModelName';
+import Tooltip from '~/components/ui/tooltip';
+import { Icons } from '~/components/ui/icons';
+import type { User } from '~/types';
+
+type ChatModel = {
+  id: string;
+  providerModelName: string;
+  contextWindow: number;
+  dollarPerInputToken: number;
+  dollarPerOutputToken: number;
+  recommended: boolean;
+  censored: boolean;
+  error?: string;
+  info?: string;
+  aiProvider?: {
+    id: string;
+    name: string;
+  };
+  aggregateChatCompletions?: {
+    avgTimeTakenMs: number;
+  };
+};
+
+type ChatModelItemProps = {
+  chatModel: ChatModel;
+};
+
+export function ChatModelItem({ chatModel }: ChatModelItemProps) {
+  const me = useRouteLoaderData('routes/_main') as User;
+  return (
+    <Accordion.Item key={chatModel.id} value={chatModel.id} className='bg-white rounded-xl shadow-bottom-level-1 overflow-hidden'>
+      <div className='relative'>
+        <Accordion.Trigger className='group flex w-full items-center justify-between p-5 text-left hover:bg-neutral-05 transition-colors'>
+          <div className='flex items-center gap-3 flex-1'>
+            {/* Provider Icon */}
+            {chatModel.aiProvider && (
+              <div className='size-8 flex-shrink-0'>
+                <img
+                  src={getPicture(chatModel.aiProvider, 'ai-providers', false)}
+                  alt={chatModel.aiProvider.name}
+                  className='size-full object-cover rounded-lg'
+                  loading='lazy'
+                />
+              </div>
+            )}
+
+            {/* Model Info */}
+            <div className='flex flex-col flex-1 min-w-0'>
+              <div className='flex items-center gap-2 mb-1'>
+                {chatModel.error && (
+                  <Tooltip
+                    side={'top'}
+                    trigger={<Icons.warning className='size-4 text-specials-danger flex-shrink-0' />}
+                    content={chatModel.error}
+                    popoverClassName='max-w-[350px]'
+                  />
+                )}
+                <span className='font-semibold text-lg text-base-black truncate'>{formatModelName(chatModel.providerModelName)}</span>
+                <RecommendedBadge recommended={chatModel.recommended} tooltipText='Recommended' />
+              </div>
+
+              {chatModel.aiProvider && <span className='text-sm text-neutral-01'>{chatModel.aiProvider.name}</span>}
+            </div>
+
+            {/* Quick Stats */}
+            <div className='hidden sm:flex items-center gap-6 text-sm text-neutral-01'>
+              <div className='text-center'>
+                <div className='font-medium text-base-black'>{chatModel.contextWindow.toLocaleString()}</div>
+                <div>Context</div>
+              </div>
+              <div className='text-center'>
+                <div className='font-medium text-base-black'>${scientificNumConvert(chatModel.dollarPerInputToken * 1000000)}</div>
+                <div>Input</div>
+              </div>
+              <div className='text-center'>
+                <div className='font-medium text-base-black'>${scientificNumConvert(chatModel.dollarPerOutputToken * 1000000)}</div>
+                <div>Output</div>
+              </div>
+            </div>
+          </div>
+
+          <Icons.chevronDown className='size-5 text-neutral-01 transition-transform duration-200 group-data-[state=open]:rotate-180 ml-2 flex-shrink-0' />
+        </Accordion.Trigger>
+      </div>
+
+      <Accordion.Content className='overflow-hidden data-[state=open]:animate-accordion-down data-[state=closed]:animate-accordion-up'>
+        <div className='px-5 pb-5'>
+          <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 pt-4 border-t border-neutral-04'>
+            <div className='space-y-1'>
+              <label className='text-sm font-medium text-neutral-01'>Context Window</label>
+              <div className='text-base font-semibold text-base-black'>{chatModel.contextWindow.toLocaleString()} tokens</div>
+            </div>
+
+            <div className='space-y-1'>
+              <label className='text-sm font-medium text-neutral-01'>Input Cost</label>
+              <div className='text-base font-semibold text-base-black'>
+                ${scientificNumConvert(chatModel.dollarPerInputToken * 1000000)}/1M tokens
+              </div>
+            </div>
+
+            <div className='space-y-1'>
+              <label className='text-sm font-medium text-neutral-01'>Output Cost</label>
+              <div className='text-base font-semibold text-base-black'>
+                ${scientificNumConvert(chatModel.dollarPerOutputToken * 1000000)}/1M tokens
+              </div>
+            </div>
+
+            <div className='space-y-1'>
+              <label className='text-sm font-medium text-neutral-01'>Average Response Time</label>
+              <div className='text-base font-semibold text-base-black'>{chatModel.aggregateChatCompletions?.avgTimeTakenMs || '--'} ms</div>
+            </div>
+
+            {chatModel.info && (
+              <div className='space-y-1 sm:col-span-2 lg:col-span-4'>
+                <label className='text-sm font-medium text-neutral-01'>Additional Info</label>
+                <div className='text-sm text-base-black bg-neutral-05 p-3 rounded-lg'>{chatModel.info}</div>
+              </div>
+            )}
+
+            <div className='space-y-1 sm:col-span-2 lg:col-span-4'>
+              <label className='text-sm font-medium text-neutral-01'>Features</label>
+              <div className='flex flex-wrap gap-2'>
+                {chatModel.recommended && (
+                  <span className='px-2 py-1 bg-gradient-1 text-base-black text-xs font-medium rounded-full'>Recommended</span>
+                )}
+                {chatModel.censored && (
+                  <span className='px-2 py-1 bg-neutral-04 text-neutral-01 text-xs font-medium rounded-full'>Censored</span>
+                )}
+                {!chatModel.censored && (
+                  <span className='px-2 py-1 bg-green-100 text-green-700 text-xs font-medium rounded-full'>Uncensored</span>
+                )}
+              </div>
+            </div>
+
+            {/* Actions */}
+            {me && me.role === 'ADMIN' && (
+              <div className='sm:col-span-2 lg:col-span-4 pt-4 border-t border-neutral-04'>
+                <div className='flex gap-3'>
+                  <Button.Root asChild variant='primary' size='sm' className='px-4'>
+                    <Link to={`/chat-models/${chatModel.id}/edit`}>Edit</Link>
+                  </Button.Root>
+                  <Button.Root asChild variant='danger' size='sm' className='px-4'>
+                    <Link to={`/chat-models/${chatModel.id}/delete`}>
+                      <Button.Icon as={Icons.trash} />
+                      Delete
+                    </Link>
+                  </Button.Root>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </Accordion.Content>
+    </Accordion.Item>
+  );
+}

--- a/app/components/chat-models/ChatModelSkeleton.tsx
+++ b/app/components/chat-models/ChatModelSkeleton.tsx
@@ -1,0 +1,19 @@
+type ChatModelSkeletonProps = {
+  count?: number;
+};
+
+export function ChatModelSkeleton({ count = 3 }: ChatModelSkeletonProps) {
+  return (
+    <div className='flex flex-col gap-10 pb-5'>
+      {Array.from({ length: count }).map((_, i) => (
+        <div key={i} className='flex flex-col gap-4'>
+          <div className='rounded-[10px] h-6 bg-gradient-1 w-full max-w-[200px] animate-pulse'></div>
+          <div className='flex flex-col gap-3'>
+            <div className='rounded-[10px] h-[110px] bg-gradient-1 w-full animate-pulse'></div>
+            <div className='rounded-[10px] h-[110px] bg-gradient-1 w-full animate-pulse'></div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/app/components/chat-models/ChatModelsFilters.tsx
+++ b/app/components/chat-models/ChatModelsFilters.tsx
@@ -1,0 +1,263 @@
+import { useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router';
+import * as Button from '~/components/ui/button/button';
+import * as Input from '~/components/ui/input/input';
+import * as Checkbox from '@radix-ui/react-checkbox';
+import * as Popover from '~/components/ui/popover';
+import { Icons } from '~/components/ui/icons';
+
+type LocalFilters = {
+  contextWindowMin: string;
+  contextWindowMax: string;
+  dollarPerInputTokenMin: string;
+  dollarPerInputTokenMax: string;
+  dollarPerOutputTokenMin: string;
+  dollarPerOutputTokenMax: string;
+  recommended: boolean;
+  censored: boolean;
+};
+
+type ChatModelsFiltersProps = {
+  hasActiveFilters: boolean;
+  activeFilterCount: number;
+  localFilters: LocalFilters;
+  onLocalFilterChange: (key: string, value: string | boolean) => void;
+  onApplyFilters: () => void;
+  onResetFilters: () => void;
+};
+
+// Separate component to prevent re-creation on every render
+function FilterInputs({ 
+  localFilters, 
+  onLocalFilterChange 
+}: { 
+  localFilters: LocalFilters; 
+  onLocalFilterChange: (key: string, value: string | boolean) => void;
+}) {
+  return (
+    <>
+      <div className='grid grid-cols-1 md:grid-cols-2 gap-4'>
+        <div className='flex flex-col gap-2'>
+          <label className='text-sm font-medium text-neutral-01'>Context Window (Min)</label>
+          <Input.Root>
+            <Input.Input
+              type='number'
+              placeholder='e.g. 4000'
+              value={localFilters.contextWindowMin}
+              onChange={(e) => onLocalFilterChange('contextWindowMin', e.target.value)}
+            />
+          </Input.Root>
+        </div>
+
+        <div className='flex flex-col gap-2'>
+          <label className='text-sm font-medium text-neutral-01'>Context Window (Max)</label>
+          <Input.Root>
+            <Input.Input
+              type='number'
+              placeholder='e.g. 128000'
+              value={localFilters.contextWindowMax}
+              onChange={(e) => onLocalFilterChange('contextWindowMax', e.target.value)}
+            />
+          </Input.Root>
+        </div>
+
+        <div className='flex flex-col gap-2'>
+          <label className='text-sm font-medium text-neutral-01'>Input Price Min ($)</label>
+          <Input.Root>
+            <Input.Input
+              type='number'
+              step='0.000001'
+              placeholder='e.g. 0.000001'
+              value={localFilters.dollarPerInputTokenMin}
+              onChange={(e) => onLocalFilterChange('dollarPerInputTokenMin', e.target.value)}
+            />
+          </Input.Root>
+        </div>
+
+        <div className='flex flex-col gap-2'>
+          <label className='text-sm font-medium text-neutral-01'>Input Price Max ($)</label>
+          <Input.Root>
+            <Input.Input
+              type='number'
+              step='0.000001'
+              placeholder='e.g. 0.00001'
+              value={localFilters.dollarPerInputTokenMax}
+              onChange={(e) => onLocalFilterChange('dollarPerInputTokenMax', e.target.value)}
+            />
+          </Input.Root>
+        </div>
+
+        <div className='flex flex-col gap-2'>
+          <label className='text-sm font-medium text-neutral-01'>Output Price Min ($)</label>
+          <Input.Root>
+            <Input.Input
+              type='number'
+              step='0.000001'
+              placeholder='e.g. 0.000001'
+              value={localFilters.dollarPerOutputTokenMin}
+              onChange={(e) => onLocalFilterChange('dollarPerOutputTokenMin', e.target.value)}
+            />
+          </Input.Root>
+        </div>
+
+        <div className='flex flex-col gap-2'>
+          <label className='text-sm font-medium text-neutral-01'>Output Price Max ($)</label>
+          <Input.Root>
+            <Input.Input
+              type='number'
+              step='0.000001'
+              placeholder='e.g. 0.00001'
+              value={localFilters.dollarPerOutputTokenMax}
+              onChange={(e) => onLocalFilterChange('dollarPerOutputTokenMax', e.target.value)}
+            />
+          </Input.Root>
+        </div>
+      </div>
+
+      <div className='flex flex-wrap gap-4 mt-4'>
+        <div className='flex items-center space-x-2'>
+          <Checkbox.Root
+            id='recommended'
+            checked={localFilters.recommended}
+            onCheckedChange={(checked) => onLocalFilterChange('recommended', !!checked)}
+            className='flex size-4 appearance-none items-center justify-center rounded-sm border border-neutral-04 bg-white data-[state=checked]:bg-primary data-[state=checked]:border-primary'
+          >
+            <Checkbox.Indicator className='text-white'>
+              <Icons.check className='size-3' />
+            </Checkbox.Indicator>
+          </Checkbox.Root>
+          <label 
+            htmlFor='recommended' 
+            className='text-sm font-medium text-neutral-01 cursor-pointer'
+            onClick={() => onLocalFilterChange('recommended', !localFilters.recommended)}
+          >
+            Recommended only
+          </label>
+        </div>
+
+        <div className='flex items-center space-x-2'>
+          <Checkbox.Root
+            id='censored'
+            checked={localFilters.censored}
+            onCheckedChange={(checked) => onLocalFilterChange('censored', !!checked)}
+            className='flex size-4 appearance-none items-center justify-center rounded-sm border border-neutral-04 bg-white data-[state=checked]:bg-primary data-[state=checked]:border-primary'
+          >
+            <Checkbox.Indicator className='text-white'>
+              <Icons.check className='size-3' />
+            </Checkbox.Indicator>
+          </Checkbox.Root>
+          <label 
+            htmlFor='censored' 
+            className='text-sm font-medium text-neutral-01 cursor-pointer'
+            onClick={() => onLocalFilterChange('censored', !localFilters.censored)}
+          >
+            Censored only
+          </label>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export function ChatModelsFilters({
+  hasActiveFilters,
+  activeFilterCount,
+  localFilters,
+  onLocalFilterChange,
+  onApplyFilters,
+  onResetFilters,
+}: ChatModelsFiltersProps) {
+  const [filtersOpen, setFiltersOpen] = useState(false);
+
+  const handleApply = () => {
+    onApplyFilters();
+    setFiltersOpen(false);
+  };
+
+  const handleReset = () => {
+    onResetFilters();
+    setFiltersOpen(false);
+  };
+
+  return (
+    <div className='flex items-center justify-end'>
+      {/* Desktop Filters Popover */}
+      <div className='hidden md:block'>
+        <Popover.Root open={filtersOpen} onOpenChange={setFiltersOpen}>
+          <Popover.Trigger asChild>
+            <Button.Root
+              variant={hasActiveFilters ? 'primary' : 'secondary'}
+              className='px-3.5 sm:px-5 sm:h-12 h-10'
+            >
+              <Button.Icon as={Icons.preferences} />
+              Filters
+              {hasActiveFilters && (
+                <span className='ml-1 bg-white text-black rounded-full size-5 text-xs flex items-center justify-center'>
+                  {activeFilterCount}
+                </span>
+              )}
+            </Button.Root>
+          </Popover.Trigger>
+          <Popover.Content side='bottom' align='end' className='w-[600px] max-h-[80vh] overflow-y-auto'>
+            <div className='p-5'>
+              <h3 className='text-lg font-semibold mb-4'>Filter Chat Models</h3>
+              <FilterInputs localFilters={localFilters} onLocalFilterChange={onLocalFilterChange} />
+              <div className='flex justify-between mt-4 pt-4 border-t border-neutral-04'>
+                <Button.Root onClick={handleReset} variant='secondary' className='px-4 py-2'>
+                  Reset
+                </Button.Root>
+                <Button.Root onClick={handleApply} variant='primary' className='px-4 py-2'>
+                  Apply Filters
+                </Button.Root>
+              </div>
+            </div>
+          </Popover.Content>
+        </Popover.Root>
+      </div>
+
+      {/* Mobile Filters Button */}
+      <div className='md:hidden'>
+        <Button.Root
+          onClick={() => setFiltersOpen(!filtersOpen)}
+          variant={hasActiveFilters ? 'primary' : 'secondary'}
+          className='px-3.5 h-10'
+        >
+          <Button.Icon as={Icons.preferences} />
+          Filters
+          {hasActiveFilters && (
+            <span className='ml-1 bg-white text-black rounded-full size-5 text-xs flex items-center justify-center'>
+              {activeFilterCount}
+            </span>
+          )}
+        </Button.Root>
+      </div>
+
+      {/* Mobile Filters Panel */}
+      {filtersOpen && (
+        <div className='md:hidden fixed inset-0 z-50 bg-black/50' onClick={() => setFiltersOpen(false)}>
+          <div className='absolute bottom-0 left-0 right-0 bg-white rounded-t-xl p-5 max-h-[90vh] overflow-y-auto' onClick={(e) => e.stopPropagation()}>
+            <div className='flex items-center justify-between mb-4'>
+              <h3 className='text-lg font-semibold'>Filter Chat Models</h3>
+              <button onClick={() => setFiltersOpen(false)} className='p-1'>
+                <Icons.close className='size-5' />
+              </button>
+            </div>
+            <div className='grid grid-cols-1 gap-4'>
+              <FilterInputs localFilters={localFilters} onLocalFilterChange={onLocalFilterChange} />
+              <div className='flex justify-between pt-4 border-t border-neutral-04 gap-3'>
+                <Button.Root onClick={handleReset} variant='secondary' className='flex-1 px-4 py-2'>
+                  Reset
+                </Button.Root>
+                <Button.Root onClick={handleApply} variant='primary' className='flex-1 px-4 py-2'>
+                  Apply Filters
+                </Button.Root>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export type { LocalFilters };

--- a/app/components/ui/search-chat-models.tsx
+++ b/app/components/ui/search-chat-models.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import * as Input from '~/components/ui/input/input';
+import { Icons } from '~/components/ui/icons';
+import { useSearchParams, useNavigate } from 'react-router';
+import { useEffect, useState, useCallback, useRef } from 'react';
+
+const SearchChatModels = () => {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const [searchValue, setSearchValue] = useState(searchParams.get('providerModelName') || '');
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  // Update local state when URL changes
+  useEffect(() => {
+    const urlValue = searchParams.get('providerModelName') || '';
+    setSearchValue(urlValue);
+  }, [searchParams]);
+
+  // Handle search with proper debounce
+  useEffect(() => {
+    // Clear any existing timeout
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+    
+    timeoutRef.current = setTimeout(() => {
+      const currentName = searchParams.get('providerModelName') || '';
+      const trimmedValue = searchValue.trim();
+      
+      // Only navigate if the search value is different from current URL param
+      if (trimmedValue !== currentName) {
+        const newSearchParams = new URLSearchParams(searchParams);
+        if (trimmedValue) {
+          newSearchParams.set('providerModelName', trimmedValue);
+        } else {
+          newSearchParams.delete('providerModelName');
+        }
+        
+        // Ensure we stay in models view and chat-models tab
+        newSearchParams.set('view', 'models');
+        newSearchParams.set('tab', 'chat-models');
+        
+        navigate(`/services/ai?${newSearchParams.toString()}`);
+      }
+    }, 300);
+    
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, [searchValue, searchParams, navigate]);
+
+  const handleInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setSearchValue(value);
+  }, []);
+
+  return (
+    <Input.Root>
+      <Input.Input
+        id='providerModelName'
+        name='providerModelName'
+        type='text'
+        placeholder='Search chat models by name'
+        className='py-3.5 pl-[52px]'
+        value={searchValue}
+        onChange={handleInputChange}
+        autoComplete='off'
+      />
+      <Input.Icon as={Icons.search} className='[&_svg]:size-6' />
+    </Input.Root>
+  );
+};
+
+export default SearchChatModels;

--- a/app/routes/_main._general.services.ai.tsx
+++ b/app/routes/_main._general.services.ai.tsx
@@ -1,9 +1,10 @@
 import { Outlet, useNavigate, useSearchParams } from 'react-router';
-import React, { useEffect, useMemo, useState } from 'react';
-import type { AiProvidersPaginated, ChatModel, EmbeddingModel } from '~/types';
+import { useEffect, useMemo, useState } from 'react';
+import type { AiProvidersPaginated, ChatModelsPaginated } from '~/types';
+import { ModelTabs, type EmbeddingModelsPaginated, type ReasoningModelsPaginated } from '~/components/ai-services/ModelTabs';
+import { ChatModelsFilters, type LocalFilters } from '~/components/chat-models/ChatModelsFilters';
+import { chatModelColumns, embeddingModelColumns, reasoningModelColumns } from '~/components/ai-services/TableDefinitions';
 import type { Route } from './+types/_main._general.services.ai';
-import type { TTableColumn } from '~/components/Table';
-import Table from '~/components/Table';
 import { scientificNumConvert } from '~/utils/scientificNumConvert';
 import { DataCard } from '~/components/DataCard';
 import { Fragment } from 'react/jsx-runtime';
@@ -17,6 +18,8 @@ import Tooltip from '~/components/ui/tooltip';
 import { Icons } from '~/components/ui/icons';
 import SearchAiProviders from '~/components/ui/search-ai-providers';
 import { useInfiniteScroll } from '~/hooks/useInfiniteScroll';
+import { AiServicesTabs } from '~/components/ai-services/AiServicesTabs';
+import Table from '~/components/Table';
 
 function AiProviderSkeleton({ count = 3 }: { count?: number }) {
   return (
@@ -35,29 +38,198 @@ function AiProviderSkeleton({ count = 3 }: { count?: number }) {
 }
 
 export function meta({}: Route.MetaArgs) {
-  return [{ title: 'AI Providers' }];
+  return [{ title: 'AI Services' }];
 }
 
 export async function clientLoader({ request }: Route.LoaderArgs) {
   const url = new URL(request.url);
   const searchParams = url.searchParams;
+  const viewMode = searchParams.get('view') || 'providers';
+  const activeTab = searchParams.get('tab') || 'chat-models';
 
+  // Always fetch AI providers for the providers view
   const aiProvidersPaginated = await fetchPaginatedData<AiProvidersPaginated>('ai-providers', searchParams, 1, 10);
+
+  // Fetch model data based on current tab when in models view
+  let chatModelsPaginated: ChatModelsPaginated | null = null;
+  let embeddingModelsPaginated: EmbeddingModelsPaginated | null = null;
+  let reasoningModelsPaginated: ReasoningModelsPaginated | null = null;
+
+  if (viewMode === 'models') {
+    try {
+      if (activeTab === 'chat-models') {
+        chatModelsPaginated = await fetchPaginatedData<ChatModelsPaginated>('chat-models', searchParams, 1, 10);
+      } else if (activeTab === 'embedding-models') {
+        const embeddingResult = await fetchPaginatedData<any>('embedding-models', searchParams, 1, 10);
+        
+        // Handle case where API returns array directly instead of paginated format
+        embeddingModelsPaginated = Array.isArray(embeddingResult) ? {
+          data: embeddingResult,
+          meta: { total: embeddingResult.length, page: 1, limit: embeddingResult.length, totalPages: 1 }
+        } : embeddingResult;
+      } else if (activeTab === 'reasoning-models') {
+        const reasoningResult = await fetchPaginatedData<any>('reasoning-models', searchParams, 1, 10);
+        
+        // Handle case where API returns array directly instead of paginated format
+        reasoningModelsPaginated = Array.isArray(reasoningResult) ? {
+          data: reasoningResult,
+          meta: { total: reasoningResult.length, page: 1, limit: reasoningResult.length, totalPages: 1 }
+        } : reasoningResult;
+      }
+    } catch (error) {
+      console.error('Error fetching model data:', error);
+      // Return empty data structure on error to prevent crashes
+      if (activeTab === 'chat-models') {
+        chatModelsPaginated = { data: [], meta: { total: 0, page: 1, limit: 10, totalPages: 1 } };
+      } else if (activeTab === 'embedding-models') {
+        embeddingModelsPaginated = { data: [], meta: { total: 0, page: 1, limit: 10, totalPages: 1 } };
+      } else if (activeTab === 'reasoning-models') {
+        reasoningModelsPaginated = { data: [], meta: { total: 0, page: 1, limit: 10, totalPages: 1 } };
+      }
+    }
+  }
 
   return {
     aiProvidersPaginated,
+    chatModelsPaginated,
+    embeddingModelsPaginated,
+    reasoningModelsPaginated,
     searchParams: Object.fromEntries(searchParams.entries()),
   };
 }
 
-export default function AiProvidersIndex({ loaderData }: Route.ComponentProps) {
-  const { aiProvidersPaginated, searchParams: initialSearchParams } = loaderData;
+export default function AiServicesIndex({ loaderData }: Route.ComponentProps) {
+  const {
+    aiProvidersPaginated,
+    chatModelsPaginated,
+    embeddingModelsPaginated,
+    reasoningModelsPaginated,
+    searchParams: initialSearchParams,
+  } = loaderData;
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const [hasInitiallyLoaded, setHasInitiallyLoaded] = useState(false);
 
-  const searchQuery = searchParams.get('name') || '';
-  const hasActiveFilters = searchQuery.length > 0;
+  // Get view mode from URL - 'providers' (default) or 'models'
+  const viewMode = searchParams.get('view') || 'providers';
+  const activeTab = searchParams.get('tab') || 'chat-models';
+
+  // Chat Models Filter Logic (only for chat-models tab)
+  const contextWindowMin = searchParams.get('contextWindowMin') || '';
+  const contextWindowMax = searchParams.get('contextWindowMax') || '';
+  const dollarPerInputTokenMin = searchParams.get('dollarPerInputTokenMin') || '';
+  const dollarPerInputTokenMax = searchParams.get('dollarPerInputTokenMax') || '';
+  const dollarPerOutputTokenMin = searchParams.get('dollarPerOutputTokenMin') || '';
+  const dollarPerOutputTokenMax = searchParams.get('dollarPerOutputTokenMax') || '';
+  const recommended = searchParams.get('recommended') === 'true';
+  const censored = searchParams.get('censored') === 'true';
+
+  // Local filter state for form inputs
+  const [localFilters, setLocalFilters] = useState<LocalFilters>({
+    contextWindowMin: contextWindowMin,
+    contextWindowMax: contextWindowMax,
+    dollarPerInputTokenMin: dollarPerInputTokenMin,
+    dollarPerInputTokenMax: dollarPerInputTokenMax,
+    dollarPerOutputTokenMin: dollarPerOutputTokenMin,
+    dollarPerOutputTokenMax: dollarPerOutputTokenMax,
+    recommended: recommended,
+    censored: censored,
+  });
+
+  // Update local state when URL params change
+  useEffect(() => {
+    setLocalFilters({
+      contextWindowMin: contextWindowMin,
+      contextWindowMax: contextWindowMax,
+      dollarPerInputTokenMin: dollarPerInputTokenMin,
+      dollarPerInputTokenMax: dollarPerInputTokenMax,
+      dollarPerOutputTokenMin: dollarPerOutputTokenMin,
+      dollarPerOutputTokenMax: dollarPerOutputTokenMax,
+      recommended: recommended,
+      censored: censored,
+    });
+  }, [contextWindowMin, contextWindowMax, dollarPerInputTokenMin, dollarPerInputTokenMax, dollarPerOutputTokenMin, dollarPerOutputTokenMax, recommended, censored]);
+
+  const hasActiveFilters =
+    contextWindowMin.length > 0 ||
+    contextWindowMax.length > 0 ||
+    dollarPerInputTokenMin.length > 0 ||
+    dollarPerInputTokenMax.length > 0 ||
+    dollarPerOutputTokenMin.length > 0 ||
+    dollarPerOutputTokenMax.length > 0 ||
+    recommended ||
+    censored;
+
+  const activeFilterCount = [
+    contextWindowMin.length > 0,
+    contextWindowMax.length > 0,
+    dollarPerInputTokenMin.length > 0,
+    dollarPerInputTokenMax.length > 0,
+    dollarPerOutputTokenMin.length > 0,
+    dollarPerOutputTokenMax.length > 0,
+    recommended,
+    censored,
+  ].filter(Boolean).length;
+
+  const handleLocalFilterChange = (key: string, value: string | boolean) => {
+    setLocalFilters(prev => ({
+      ...prev,
+      [key]: value
+    }));
+  };
+
+  const handleApplyFilters = () => {
+    const newSearchParams = new URLSearchParams(searchParams);
+    
+    // Apply all local filter values to URL
+    Object.entries(localFilters).forEach(([key, value]) => {
+      if (value === '' || value === false) {
+        newSearchParams.delete(key);
+      } else {
+        newSearchParams.set(key, value.toString());
+      }
+    });
+
+    // Keep current tab in URL
+    newSearchParams.set('tab', 'chat-models');
+    navigate(`/services/ai?${newSearchParams.toString()}`);
+  };
+
+  const handleResetFilters = () => {
+    // Reset local state
+    setLocalFilters({
+      contextWindowMin: '',
+      contextWindowMax: '',
+      dollarPerInputTokenMin: '',
+      dollarPerInputTokenMax: '',
+      dollarPerOutputTokenMin: '',
+      dollarPerOutputTokenMax: '',
+      recommended: false,
+      censored: false,
+    });
+    // Immediately clear URL filters (keep view, tab, and providerModelName search)
+    const newSearchParams = new URLSearchParams();
+    const currentSearch = searchParams.get('providerModelName');
+    const currentView = searchParams.get('view');
+    const currentTab = searchParams.get('tab');
+    
+    if (currentSearch) {
+      newSearchParams.set('providerModelName', currentSearch);
+    }
+    if (currentView) {
+      newSearchParams.set('view', currentView);
+    }
+    if (currentTab) {
+      newSearchParams.set('tab', currentTab);
+    }
+    
+    navigate(`/services/ai?${newSearchParams.toString()}`, { replace: true });
+  };
+
+  const providersSearchQuery = searchParams.get('name') || '';
+
+  // Active filters depend on the current view mode  
+  const providersHasActiveFilters = providersSearchQuery.length > 0;
 
   const fetchMoreWithParams = async (page: number) => {
     const currentSearchParams = new URLSearchParams(initialSearchParams);
@@ -79,6 +251,15 @@ export default function AiProvidersIndex({ loaderData }: Route.ComponentProps) {
 
   const handleClearFilters = () => {
     navigate('/services/ai', { replace: true });
+  };
+
+  const handleViewModeChange = (mode: 'providers' | 'models') => {
+    const newSearchParams = new URLSearchParams(searchParams);
+    newSearchParams.set('view', mode);
+    if (mode === 'models' && !newSearchParams.has('tab')) {
+      newSearchParams.set('tab', 'chat-models');
+    }
+    navigate(`/services/ai?${newSearchParams.toString()}`, { replace: true });
   };
 
   const filteredAiProviders = useMemo(() => {
@@ -104,509 +285,378 @@ export default function AiProvidersIndex({ loaderData }: Route.ComponentProps) {
     );
   }
 
-  const chatModelColumns: Array<TTableColumn<ChatModel>> = [
-    {
-      id: 'providerModelName',
-      label: 'Chat model',
-      render: (data) => (
-        <span className='font-semibold text-body-md flex items-center gap-2'>
-          {data.error && (
-            <Tooltip
-              side={'top'}
-              trigger={<Icons.warning className='size-4 text-specials-danger' />}
-              content={data.error}
-              popoverClassName='max-w-[350px]'
-            />
-          )}
-          {formatModelName(data.providerModelName)}
-          <RecommendedBadge recommended={data.recommended} tooltipText='Recommended' />
-        </span>
-      ),
-      align: 'left',
-      className: 'min-w-[220px] max-w-[280px]',
-    },
-    {
-      id: 'aiProviderId',
-      label: '',
-      render: (data) => <span className='text-body-sm text-neutral-01'>{data.info}</span>,
-      align: 'left',
-    },
-    {
-      id: 'dollarPerInputToken',
-      label: 'Input',
-      render: (data) => <span className='text-sm'>${scientificNumConvert(data.dollarPerInputToken * 1000000)}</span>,
-      align: 'right',
-      width: '104px',
-      tooltipText: 'The cost of processing one million tokens that you send to the model',
-    },
-    {
-      id: 'dollarPerOutputToken',
-      label: 'Output',
-      render: (data) => <span className='text-sm'>${scientificNumConvert(data.dollarPerOutputToken * 1000000)}</span>,
-      align: 'right',
-      width: '104px',
-      tooltipText: 'Cost 1 unit of the token you received at the same rate',
-    },
-    {
-      id: 'id',
-      label: '',
-      render: (data) => (
-        <ViewButton
-          popoverItems={[
-            { text: 'Edit', href: `/services/ai/chat-models/${data.id}/edit` },
-            { text: 'Delete', href: `/services/ai/chat-models/${data.id}/delete`, isDelete: true },
-          ]}
-          className='flex items-center justify-center'
-          isDataCard={true}
-        />
-      ),
-      width: '44px',
-      align: 'right',
-    },
-  ];
 
-  const embeddingModelColumns: Array<TTableColumn<EmbeddingModel>> = [
-    {
-      id: 'providerModelName',
-      label: 'Embedding model',
-      render: (data) => (
-        <span className='font-semibold text-body-md flex items-center gap-2'>
-          {data.error && (
-            <Tooltip
-              side={'top'}
-              trigger={<Icons.warning className='size-4 text-specials-danger' />}
-              content={data.error}
-              className='max-w-[350px]'
-            />
-          )}
-          {formatModelName(data.providerModelName)}
-          <RecommendedBadge recommended={data.recommended} tooltipText='Recommended' />
-        </span>
-      ),
-      align: 'left',
-      className: 'min-w-[220px] max-w-[280px]',
-    },
-    {
-      id: 'aiProviderId',
-      label: '',
-      render: (data) => <span className='text-body-sm text-neutral-01'>{data.info}</span>,
-      align: 'left',
-    },
-    {
-      id: 'dollarPerInputToken',
-      label: 'Input',
-      render: (data) => <span className='text-sm'>${scientificNumConvert(data.dollarPerInputToken * 1000000)}</span>,
-      align: 'right',
-      width: '104px',
-      tooltipText: 'The cost of processing one million tokens that you send to the model',
-    },
-    {
-      id: 'dollarPerOutputToken',
-      label: 'Output',
-      render: (data) => <span className='text-sm'>${scientificNumConvert(data.dollarPerOutputToken * 1000000)}</span>,
-      align: 'right',
-      width: '104px',
-      tooltipText: 'Cost 1 unit of the token you received at the same rate',
-    },
-    {
-      id: 'id',
-      label: '',
-      render: (data) => (
-        <ViewButton
-          popoverItems={[
-            { text: 'Edit', href: `/services/ai/embedding-models/${data.id}/edit` },
-            { text: 'Delete', href: `/services/ai/embedding-models/${data.id}/delete`, isDelete: true },
-          ]}
-          className='flex items-center justify-center'
-          isDataCard={true}
-        />
-      ),
-      width: '44px',
-      align: 'right',
-    },
-  ];
 
-  const reasoningModelColumns: Array<TTableColumn<ChatModel>> = [
-    {
-      id: 'providerModelName',
-      label: 'Reasoning model',
-      render: (data) => (
-        <span className='font-semibold text-body-md flex items-center gap-2'>
-          {data.error && (
-            <Tooltip
-              side={'top'}
-              trigger={<Icons.warning className='size-4 text-specials-danger' />}
-              content={data.error}
-              className='max-w-[350px]'
-            />
-          )}
-          {formatModelName(data.providerModelName)}
-          <RecommendedBadge recommended={data.recommended} tooltipText='Recommended' />
-        </span>
-      ),
-      align: 'left',
-      className: 'min-w-[220px] max-w-[280px]',
-    },
-    {
-      id: 'aiProviderId',
-      label: '',
-      render: (data) => <span className='text-body-sm text-neutral-01'>{data.info}</span>,
-      align: 'left',
-    },
-    {
-      id: 'dollarPerInputToken',
-      label: 'Input',
-      render: (data) => <span className='text-sm'>${scientificNumConvert(data.dollarPerInputToken * 1000000)}</span>,
-      align: 'right',
-      width: '104px',
-      tooltipText: 'The cost of processing one million tokens that you send to the model',
-    },
-    {
-      id: 'dollarPerOutputToken',
-      label: 'Output',
-      render: (data) => <span className='text-sm'>${scientificNumConvert(data.dollarPerOutputToken * 1000000)}</span>,
-      align: 'right',
-      width: '104px',
-      tooltipText: 'Cost 1 unit of the token you received at the same rate',
-    },
-    {
-      id: 'id',
-      label: '',
-      render: (data) => (
-        <ViewButton
-          popoverItems={[
-            { text: 'Edit', href: `/services/ai/reasoning-models/${data.id}/edit` },
-            { text: 'Delete', href: `/services/ai/reasoning-models/${data.id}/delete`, isDelete: true },
-          ]}
-          className='flex items-center justify-center'
-          isDataCard={true}
-        />
-      ),
-      width: '44px',
-      align: 'right',
-    },
-  ];
+
+  // Create filter component for chat models tab
+  const chatModelsFilterComponent = activeTab === 'chat-models' ? (
+    <ChatModelsFilters
+      hasActiveFilters={hasActiveFilters}
+      activeFilterCount={activeFilterCount}
+      localFilters={localFilters}
+      onLocalFilterChange={handleLocalFilterChange}
+      onApplyFilters={handleApplyFilters}
+      onResetFilters={handleResetFilters}
+    />
+  ) : null;
+
+  const tabs = ModelTabs({ 
+    chatModelsPaginated, 
+    embeddingModelsPaginated, 
+    reasoningModelsPaginated 
+  });
+
   return (
     <>
       <div className='w-full'>
-        <div className='flex items-center justify-between sm:mt-8 mb-4'>
-          <h2 className='text-2xl font-semibold'>AI Providers</h2>
+        <div className='flex items-center justify-between sm:mt-8 mb-6'>
+          <h2 className='text-2xl font-semibold'>AI Services</h2>
+
+          {/* View Mode Toggle */}
+          <div className='flex items-center gap-2 bg-neutral-05 rounded-lg p-1'>
+            <button
+              onClick={() => handleViewModeChange('providers')}
+              className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+                viewMode === 'providers' ? 'bg-white text-base-black shadow-sm' : 'text-neutral-01 hover:text-base-black'
+              }`}
+            >
+              By Providers
+            </button>
+            <button
+              onClick={() => handleViewModeChange('models')}
+              className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+                viewMode === 'models' ? 'bg-white text-base-black shadow-sm' : 'text-neutral-01 hover:text-base-black'
+              }`}
+            >
+              By Models
+            </button>
+          </div>
         </div>
 
-        <div className='flex flex-col gap-5'>
-          <SearchAiProviders />
+        {/* Secondary Navigation - Tabs for Models or Search for Providers */}
+        <div className='mb-6'>
+          {viewMode === 'models' ? (
+            <AiServicesTabs tabs={tabs} defaultTab={activeTab} filterComponent={chatModelsFilterComponent} />
+          ) : (
+            <div className='flex flex-col gap-5'>
+              <SearchAiProviders />
 
-          {hasActiveFilters && (
-            <div className='flex items-center justify-end'>
-              <button
-                onClick={handleClearFilters}
-                className='flex items-center gap-2 px-3 py-2 rounded-lg transition-colors cursor-pointer navigation-exclude text-red-600 hover:bg-red-50'
-              >
-                <Icons.close className='size-4' />
-                <p className='text-body-md font-medium'>Clear filters</p>
-              </button>
+              {providersHasActiveFilters && (
+                <div className='flex items-center justify-end'>
+                  <button
+                    onClick={handleClearFilters}
+                    className='flex items-center gap-2 px-3 py-2 rounded-lg transition-colors cursor-pointer navigation-exclude text-red-600 hover:bg-red-50'
+                  >
+                    <Icons.close className='size-4' />
+                    <p className='text-body-md font-medium'>Clear filters</p>
+                  </button>
+                </div>
+              )}
             </div>
           )}
         </div>
-      </div>
 
-      <div className='flex flex-col gap-10 pb-5 mt-5'>
-        {filteredAiProviders.length === 0 ? (
-          <p className='text-body-md text-neutral-01 text-center'>No AI providers found.</p>
-        ) : (
-          filteredAiProviders.map((aiProvider) => {
-            return (
-              <div key={aiProvider.id} className='flex flex-col gap-5'>
-                <DataCard.Root>
-                  <DataCard.Label
-                    className='text-2xl font-semibold flex items-center gap-2'
-                    extra={
-                      <ViewButton
-                        popoverItems={[
-                          { text: 'Edit AI Provider', href: `/services/ai/ai-providers/${aiProvider.id}/edit` },
-                          {
-                            text: 'Add Chat Model',
-                            href: `/services/ai/chat-models/new?id=${aiProvider.id}&modelName=${aiProvider.name}`,
-                          },
-                          {
-                            text: 'Add Embedding Model',
-                            href: `/services/ai/embedding-models/new?id=${aiProvider.id}&modelName=${aiProvider.name}`,
-                          },
-                          {
-                            text: 'Add Reasoning Model',
-                            href: `/services/ai/reasoning-models/new?id=${aiProvider.id}&modelName=${aiProvider.name}`,
-                          },
-                          {
-                            text: 'Delete',
-                            href: `/services/ai/providers/delete?id=${aiProvider.id}&modelName=${aiProvider.name}`,
-                            isDelete: true,
-                          },
-                        ]}
-                      />
-                    }
-                  >
-                    <div className='size-6'>
-                      <img
-                        src={getPicture(aiProvider, 'ai-providers', false)}
-                        srcSet={getPicture(aiProvider, 'ai-providers', true)}
-                        alt={aiProvider.name}
-                        className='size-full object-cover rounded-lg'
-                      />
-                    </div>
-                    <div className='flex items-center gap-1'>
-                      {aiProvider.name}
-                      <InformationBadge
-                        tooltipText='High-speed AI for real-time apps and chatbots'
-                        side={{
-                          default: 'top',
-                          lg: 'right',
-                        }}
-                      />
-                    </div>
-                  </DataCard.Label>
-
-                  {/* CHAT MODELS WRAPPER */}
-                  <div className='bg-gradient-1 rounded-xl md:bg-none'>
-                    {aiProvider.chatModels.length > 0 && (
-                      <>
-                        <div className='flex items-center justify-between p-3 md:hidden'>
-                          <span className='text-xs text-neutral-01 font-semibold'>Chat model</span>
+        {/* Content Area */}
+        {viewMode === 'providers' && (
+          <div className='flex flex-col gap-10 pb-5'>
+            {filteredAiProviders.length === 0 ? (
+              <p className='text-body-md text-neutral-01 text-center'>No AI providers found.</p>
+            ) : (
+              filteredAiProviders.map((aiProvider) => {
+                return (
+                  <div key={aiProvider.id} className='flex flex-col gap-5'>
+                    <DataCard.Root>
+                      <DataCard.Label
+                        className='text-2xl font-semibold flex items-center gap-2'
+                        extra={
+                          <ViewButton
+                            popoverItems={[
+                              { text: 'Edit AI Provider', href: `/services/ai/ai-providers/${aiProvider.id}/edit` },
+                              {
+                                text: 'Add Chat Model',
+                                href: `/services/ai/chat-models/new?id=${aiProvider.id}&modelName=${aiProvider.name}`,
+                              },
+                              {
+                                text: 'Add Embedding Model',
+                                href: `/services/ai/embedding-models/new?id=${aiProvider.id}&modelName=${aiProvider.name}`,
+                              },
+                              {
+                                text: 'Add Reasoning Model',
+                                href: `/services/ai/reasoning-models/new?id=${aiProvider.id}&modelName=${aiProvider.name}`,
+                              },
+                              {
+                                text: 'Delete',
+                                href: `/services/ai/providers/delete?id=${aiProvider.id}&modelName=${aiProvider.name}`,
+                                isDelete: true,
+                              },
+                            ]}
+                          />
+                        }
+                      >
+                        <div className='size-6'>
+                          <img
+                            src={getPicture(aiProvider, 'ai-providers', false)}
+                            srcSet={getPicture(aiProvider, 'ai-providers', true)}
+                            alt={aiProvider.name}
+                            className='size-full object-cover rounded-lg'
+                          />
+                        </div>
+                        <div className='flex items-center gap-1'>
+                          {aiProvider.name}
                           <InformationBadge
-                            tooltipText='Chat model'
+                            tooltipText='High-speed AI for real-time apps and chatbots'
                             side={{
                               default: 'top',
                               lg: 'right',
                             }}
                           />
                         </div>
+                      </DataCard.Label>
 
-                        <DataCard.Wrapper>
-                          {/* DESKTOP TABLE */}
-                          <div className='md:block hidden'>
-                            <Table
-                              columns={chatModelColumns}
-                              data={aiProvider.chatModels}
-                              getRowUrl={(chatModel) => `/chat-models/${chatModel.id}`}
-                            />
-                          </div>
+                      {/* CHAT MODELS WRAPPER */}
+                      <div className='bg-gradient-1 rounded-xl md:bg-none'>
+                        {aiProvider.chatModels.length > 0 && (
+                          <>
+                            <div className='flex items-center justify-between p-3 md:hidden'>
+                              <span className='text-xs text-neutral-01 font-semibold'>Chat model</span>
+                              <InformationBadge
+                                tooltipText='Chat model'
+                                side={{
+                                  default: 'top',
+                                  lg: 'right',
+                                }}
+                              />
+                            </div>
 
-                          {/* MOBILE CARD */}
-                          <div className='block md:hidden'>
-                            {aiProvider.chatModels.map((chatModel, index) => {
-                              return (
-                                <Fragment key={chatModel.id}>
-                                  <DataCard.Item collapsible href={`/chat-models/${chatModel.id}`}>
-                                    <DataCard.ItemLabel>
-                                      <span className='flex items-center gap-2'>
-                                        {chatModel.providerModelName}
-                                        <RecommendedBadge recommended={chatModel.recommended} tooltipText='Recommended' />
-                                      </span>
-                                    </DataCard.ItemLabel>
-                                    <DataCard.ItemCollapsibleContent>
-                                      <DataCard.ItemDataGrid
-                                        data={[
-                                          {
-                                            label: 'Output',
-                                            value: <>{scientificNumConvert(chatModel.dollarPerInputToken)}</>,
-                                          },
-                                          {
-                                            label: 'Average Time Taken',
-                                            value: '1153 ms',
-                                          },
-                                        ]}
-                                        variant='secondary'
-                                      />
-                                    </DataCard.ItemCollapsibleContent>
-                                    <DataCard.ItemDataGrid
-                                      data={[
-                                        {
-                                          label: '$/Input',
-                                          value: <>${scientificNumConvert(chatModel.dollarPerInputToken)}</>,
-                                        },
-                                        {
-                                          label: '$/Output',
-                                          value: <>${scientificNumConvert(chatModel.dollarPerOutputToken)}</>,
-                                        },
-                                      ]}
-                                    />
-                                  </DataCard.Item>
-                                  {aiProvider.chatModels.length - 1 !== index && <DataCard.Divider />}
-                                </Fragment>
-                              );
-                            })}
-                          </div>
-                        </DataCard.Wrapper>
-                      </>
-                    )}
+                            <DataCard.Wrapper>
+                              {/* DESKTOP TABLE */}
+                              <div className='md:block hidden'>
+                                <Table
+                                  columns={chatModelColumns}
+                                  data={aiProvider.chatModels}
+                                  getRowUrl={(chatModel) => `/chat-models/${chatModel.id}`}
+                                />
+                              </div>
 
-                    {/* EMBEDDING MODELS WRAPPER */}
-                    {aiProvider.embeddingModels.length > 0 && (
-                      <>
-                        <div className='flex items-center justify-between px-3 pt-3 md:hidden'>
-                          <span className='text-xs text-neutral-01 font-semibold'>Embedding model</span>
-                          <Tooltip
-                            side='top'
-                            trigger={<Icons.info className='text-neutral-02 inline-block size-4' />}
-                            content={'Embedding model'}
-                          />
-                        </div>
+                              {/* MOBILE CARD */}
+                              <div className='block md:hidden'>
+                                {aiProvider.chatModels.map((chatModel, index) => {
+                                  return (
+                                    <Fragment key={chatModel.id}>
+                                      <DataCard.Item collapsible href={`/chat-models/${chatModel.id}`}>
+                                        <DataCard.ItemLabel>
+                                          <span className='flex items-center gap-2'>
+                                            {chatModel.providerModelName}
+                                            <RecommendedBadge recommended={chatModel.recommended} tooltipText='Recommended' />
+                                          </span>
+                                        </DataCard.ItemLabel>
+                                        <DataCard.ItemCollapsibleContent>
+                                          <DataCard.ItemDataGrid
+                                            data={[
+                                              {
+                                                label: 'Output',
+                                                value: <>{scientificNumConvert(chatModel.dollarPerInputToken)}</>,
+                                              },
+                                              {
+                                                label: 'Average Time Taken',
+                                                value: '1153 ms',
+                                              },
+                                            ]}
+                                            variant='secondary'
+                                          />
+                                        </DataCard.ItemCollapsibleContent>
+                                        <DataCard.ItemDataGrid
+                                          data={[
+                                            {
+                                              label: '$/Input',
+                                              value: <>${scientificNumConvert(chatModel.dollarPerInputToken)}</>,
+                                            },
+                                            {
+                                              label: '$/Output',
+                                              value: <>${scientificNumConvert(chatModel.dollarPerOutputToken)}</>,
+                                            },
+                                          ]}
+                                        />
+                                      </DataCard.Item>
+                                      {aiProvider.chatModels.length - 1 !== index && <DataCard.Divider />}
+                                    </Fragment>
+                                  );
+                                })}
+                              </div>
+                            </DataCard.Wrapper>
+                          </>
+                        )}
 
-                        <DataCard.Wrapper className='mt-3'>
-                          {/* DESKTOP TABLE */}
-                          <div className='md:block hidden'>
-                            <Table
-                              columns={embeddingModelColumns}
-                              data={aiProvider.embeddingModels}
-                              getRowUrl={(embeddingModel) => `/embedding-models/${embeddingModel.id}`}
-                            />
-                          </div>
-                          {/* MOBILE CARD */}
-                          <div className='block md:hidden'>
-                            {aiProvider.embeddingModels.map((embeddingModel, index) => {
-                              return (
-                                <Fragment key={embeddingModel.id}>
-                                  <DataCard.Item collapsible href={`/embedding-models/${embeddingModel.id}`}>
-                                    <DataCard.ItemLabel>
-                                      <span className='flex items-center gap-2'>
-                                        {formatModelName(embeddingModel.providerModelName)}
-                                        <RecommendedBadge recommended={embeddingModel.recommended} tooltipText='Recommended' />
-                                      </span>
-                                    </DataCard.ItemLabel>
-                                    <DataCard.ItemCollapsibleContent>
-                                      <DataCard.ItemDataGrid
-                                        data={[
-                                          {
-                                            label: 'Output',
-                                            value: <>{scientificNumConvert(embeddingModel.dollarPerInputToken)}</>,
-                                          },
-                                        ]}
-                                        variant='secondary'
-                                      />
-                                    </DataCard.ItemCollapsibleContent>
-                                    <DataCard.ItemDataGrid
-                                      data={[
-                                        {
-                                          label: '$/Input',
-                                          value: <>${scientificNumConvert(embeddingModel.dollarPerInputToken)}</>,
-                                        },
-                                        {
-                                          label: '$/Output',
-                                          value: <>${scientificNumConvert(embeddingModel.dollarPerOutputToken)}</>,
-                                        },
-                                      ]}
-                                    />
-                                  </DataCard.Item>
-                                  {aiProvider.embeddingModels.length - 1 !== index && <DataCard.Divider />}
-                                </Fragment>
-                              );
-                            })}
-                          </div>
-                        </DataCard.Wrapper>
-                      </>
-                    )}
+                        {/* EMBEDDING MODELS WRAPPER */}
+                        {aiProvider.embeddingModels.length > 0 && (
+                          <>
+                            <div className='flex items-center justify-between px-3 pt-3 md:hidden'>
+                              <span className='text-xs text-neutral-01 font-semibold'>Embedding model</span>
+                              <Tooltip
+                                side='top'
+                                trigger={<Icons.info className='text-neutral-02 inline-block size-4' />}
+                                content={'Embedding model'}
+                              />
+                            </div>
 
-                    {/* REASONING MODELS WRAPPER */}
-                    {aiProvider.reasoningModels && aiProvider.reasoningModels.length > 0 && (
-                      <>
-                        <div className='flex items-center justify-between px-3 pt-3 md:hidden'>
-                          <span className='text-xs text-neutral-01 font-semibold'>Reasoning model</span>
-                          <Tooltip
-                            side='top'
-                            trigger={<Icons.info className='text-neutral-02 inline-block size-4' />}
-                            content={'Reasoning model'}
-                          />
-                        </div>
+                            <DataCard.Wrapper className='mt-3'>
+                              {/* DESKTOP TABLE */}
+                              <div className='md:block hidden'>
+                                <Table
+                                  columns={embeddingModelColumns}
+                                  data={aiProvider.embeddingModels}
+                                  getRowUrl={(embeddingModel) => `/embedding-models/${embeddingModel.id}`}
+                                />
+                              </div>
+                              {/* MOBILE CARD */}
+                              <div className='block md:hidden'>
+                                {aiProvider.embeddingModels.map((embeddingModel, index) => {
+                                  return (
+                                    <Fragment key={embeddingModel.id}>
+                                      <DataCard.Item collapsible href={`/embedding-models/${embeddingModel.id}`}>
+                                        <DataCard.ItemLabel>
+                                          <span className='flex items-center gap-2'>
+                                            {formatModelName(embeddingModel.providerModelName)}
+                                            <RecommendedBadge recommended={embeddingModel.recommended} tooltipText='Recommended' />
+                                          </span>
+                                        </DataCard.ItemLabel>
+                                        <DataCard.ItemCollapsibleContent>
+                                          <DataCard.ItemDataGrid
+                                            data={[
+                                              {
+                                                label: 'Output',
+                                                value: <>{scientificNumConvert(embeddingModel.dollarPerInputToken)}</>,
+                                              },
+                                            ]}
+                                            variant='secondary'
+                                          />
+                                        </DataCard.ItemCollapsibleContent>
+                                        <DataCard.ItemDataGrid
+                                          data={[
+                                            {
+                                              label: '$/Input',
+                                              value: <>${scientificNumConvert(embeddingModel.dollarPerInputToken)}</>,
+                                            },
+                                            {
+                                              label: '$/Output',
+                                              value: <>${scientificNumConvert(embeddingModel.dollarPerOutputToken)}</>,
+                                            },
+                                          ]}
+                                        />
+                                      </DataCard.Item>
+                                      {aiProvider.embeddingModels.length - 1 !== index && <DataCard.Divider />}
+                                    </Fragment>
+                                  );
+                                })}
+                              </div>
+                            </DataCard.Wrapper>
+                          </>
+                        )}
 
-                        <DataCard.Wrapper className='mt-3'>
-                          {/* DESKTOP TABLE */}
-                          <div className='md:block hidden'>
-                            <Table
-                              columns={reasoningModelColumns}
-                              data={aiProvider.reasoningModels}
-                              getRowUrl={(reasoningModel) => `/reasoning-models/${reasoningModel.id}`}
-                            />
-                          </div>
+                        {/* REASONING MODELS WRAPPER */}
+                        {aiProvider.reasoningModels && aiProvider.reasoningModels.length > 0 && (
+                          <>
+                            <div className='flex items-center justify-between px-3 pt-3 md:hidden'>
+                              <span className='text-xs text-neutral-01 font-semibold'>Reasoning model</span>
+                              <Tooltip
+                                side='top'
+                                trigger={<Icons.info className='text-neutral-02 inline-block size-4' />}
+                                content={'Reasoning model'}
+                              />
+                            </div>
 
-                          {/* MOBILE CARD */}
-                          <div className='block md:hidden'>
-                            {aiProvider.reasoningModels.map((reasoningModel, index) => {
-                              return (
-                                <Fragment key={reasoningModel.id}>
-                                  <DataCard.Item collapsible href={`/reasoning-models/${reasoningModel.id}`}>
-                                    <DataCard.ItemLabel>
-                                      <span className='flex items-center gap-2'>
-                                        {reasoningModel.providerModelName}
-                                        <RecommendedBadge recommended={reasoningModel.recommended} tooltipText='Recommended' />
-                                      </span>
-                                    </DataCard.ItemLabel>
-                                    <DataCard.ItemCollapsibleContent>
-                                      <DataCard.ItemDataGrid
-                                        data={[
-                                          {
-                                            label: 'Output',
-                                            value: <>{scientificNumConvert(reasoningModel.dollarPerInputToken)}</>,
-                                          },
-                                          {
-                                            label: 'Average Time Taken',
-                                            value: '1153 ms',
-                                          },
-                                        ]}
-                                        variant='secondary'
-                                      />
-                                    </DataCard.ItemCollapsibleContent>
-                                    <DataCard.ItemDataGrid
-                                      data={[
-                                        {
-                                          label: '$/Input',
-                                          value: <>${scientificNumConvert(reasoningModel.dollarPerInputToken)}</>,
-                                        },
-                                        {
-                                          label: '$/Output',
-                                          value: <>${scientificNumConvert(reasoningModel.dollarPerOutputToken)}</>,
-                                        },
-                                      ]}
-                                    />
-                                  </DataCard.Item>
-                                  {aiProvider.reasoningModels.length - 1 !== index && <DataCard.Divider />}
-                                </Fragment>
-                              );
-                            })}
-                          </div>
-                        </DataCard.Wrapper>
-                      </>
-                    )}
+                            <DataCard.Wrapper className='mt-3'>
+                              {/* DESKTOP TABLE */}
+                              <div className='md:block hidden'>
+                                <Table
+                                  columns={reasoningModelColumns}
+                                  data={aiProvider.reasoningModels}
+                                  getRowUrl={(reasoningModel) => `/reasoning-models/${reasoningModel.id}`}
+                                />
+                              </div>
+
+                              {/* MOBILE CARD */}
+                              <div className='block md:hidden'>
+                                {aiProvider.reasoningModels.map((reasoningModel, index) => {
+                                  return (
+                                    <Fragment key={reasoningModel.id}>
+                                      <DataCard.Item collapsible href={`/reasoning-models/${reasoningModel.id}`}>
+                                        <DataCard.ItemLabel>
+                                          <span className='flex items-center gap-2'>
+                                            {reasoningModel.providerModelName}
+                                            <RecommendedBadge recommended={reasoningModel.recommended} tooltipText='Recommended' />
+                                          </span>
+                                        </DataCard.ItemLabel>
+                                        <DataCard.ItemCollapsibleContent>
+                                          <DataCard.ItemDataGrid
+                                            data={[
+                                              {
+                                                label: 'Output',
+                                                value: <>{scientificNumConvert(reasoningModel.dollarPerInputToken)}</>,
+                                              },
+                                              {
+                                                label: 'Average Time Taken',
+                                                value: '1153 ms',
+                                              },
+                                            ]}
+                                            variant='secondary'
+                                          />
+                                        </DataCard.ItemCollapsibleContent>
+                                        <DataCard.ItemDataGrid
+                                          data={[
+                                            {
+                                              label: '$/Input',
+                                              value: <>${scientificNumConvert(reasoningModel.dollarPerInputToken)}</>,
+                                            },
+                                            {
+                                              label: '$/Output',
+                                              value: <>${scientificNumConvert(reasoningModel.dollarPerOutputToken)}</>,
+                                            },
+                                          ]}
+                                        />
+                                      </DataCard.Item>
+                                      {aiProvider.reasoningModels.length - 1 !== index && <DataCard.Divider />}
+                                    </Fragment>
+                                  );
+                                })}
+                              </div>
+                            </DataCard.Wrapper>
+                          </>
+                        )}
+                      </div>
+
+                      {/* Show message if no models */}
+                      {aiProvider.chatModels.length === 0 &&
+                        aiProvider.embeddingModels.length === 0 &&
+                        (!aiProvider.reasoningModels || aiProvider.reasoningModels.length === 0) && (
+                          <DataCard.Wrapper>
+                            <DataCard.Text>No models found</DataCard.Text>
+                          </DataCard.Wrapper>
+                        )}
+                    </DataCard.Root>
                   </div>
+                );
+              })
+            )}
 
-                  {/* Show message if no models */}
-                  {aiProvider.chatModels.length === 0 &&
-                    aiProvider.embeddingModels.length === 0 &&
-                    (!aiProvider.reasoningModels || aiProvider.reasoningModels.length === 0) && (
-                      <DataCard.Wrapper>
-                        <DataCard.Text>No models found</DataCard.Text>
-                      </DataCard.Wrapper>
-                    )}
-                </DataCard.Root>
+            {infiniteScroll.error && (
+              <div className='text-center text-red-500 py-4'>
+                <p>Failed to load AI providers: {infiniteScroll.error}</p>
               </div>
-            );
-          })
-        )}
+            )}
 
-        {infiniteScroll.error && (
-          <div className='text-center text-red-500 py-4'>
-            <p>Failed to load AI providers: {infiniteScroll.error}</p>
+            {infiniteScroll.loading && (
+              <div className='text-center py-4'>
+                <div className='inline-flex items-center gap-2'>
+                  <Icons.loading className='size-4 animate-spin' />
+                  <span className='text-neutral-01'>Loading more AI providers...</span>
+                </div>
+              </div>
+            )}
+
+            {infiniteScroll.hasMore && !infiniteScroll.loading && <div ref={infiniteScroll.triggerRef} className='h-4' />}
           </div>
         )}
-
-        {infiniteScroll.loading && (
-          <div className='text-center py-4'>
-            <div className='inline-flex items-center gap-2'>
-              <Icons.loading className='size-4 animate-spin' />
-              <span className='text-neutral-01'>Loading more AI providers...</span>
-            </div>
-          </div>
-        )}
-
-        {infiniteScroll.hasMore && !infiniteScroll.loading && <div ref={infiniteScroll.triggerRef} className='h-4' />}
       </div>
       <Outlet />
     </>


### PR DESCRIPTION
This PR has a new feature for Services page. Default version will show the AI providers/services like before but now we do have a tab where you can see chat models, embedding models and reasoning models. You can search and filter chat models. Endpoints are not ready for embedding and reasoning models

<img width="1050" height="680" alt="Screenshot 2025-07-21 at 02 49 52" src="https://github.com/user-attachments/assets/2868391d-1e6a-44f1-9922-28fc3669b8d2" />
