### PR TITLE
added hide logic for services info banners/messages

### DIFF
--- a/app/routes/_main._general.services.tsx
+++ b/app/routes/_main._general.services.tsx
@@ -46,19 +46,28 @@ const servicesNavItems = [
   },
 ];
 
-export default function Services() {
+export async function clientLoader() {
+  return {
+    'ai-info-message': localStorage.getItem('ai-info-message') === 'hidden',
+    'tts-info-message': localStorage.getItem('tts-info-message') === 'hidden',
+    'stt-info-message': localStorage.getItem('stt-info-message') === 'hidden',
+  };
+}
+
+export default function Services({ loaderData }: Route.ComponentProps) {
   const location = useLocation();
   const navigate = useNavigate();
   const me = useRouteLoaderData('routes/_main') as User;
-
-  const [isShouldShowInfoMessage, setIsShouldShowInfoMessage] = useState(false);
+  const hiddenMessages: Record<string, boolean> = loaderData;
 
   const activeItem = useMemo(() => {
     return servicesNavItems.find((item) => location.pathname.includes(`/${item.to}`)) || servicesNavItems[0];
   }, [location.pathname]);
 
-  const handleClose = (item: string) => {
-    localStorage.setItem(item, 'hidden');
+  const [isShouldShowInfoMessage, setIsShouldShowInfoMessage] = useState(!hiddenMessages?.[activeItem.infoMessage]);
+
+  const handleClose = (activeItem: string) => {
+    localStorage.setItem(activeItem, 'hidden');
     setIsShouldShowInfoMessage(false);
   };
 
@@ -68,8 +77,8 @@ export default function Services() {
       return;
     }
 
-    setIsShouldShowInfoMessage(localStorage.getItem(activeItem.infoMessage) !== 'hidden');
-  }, [location.pathname, navigate, activeItem.infoMessage]);
+    setIsShouldShowInfoMessage(!hiddenMessages?.[activeItem.infoMessage]);
+  }, [location.pathname, navigate]);
 
   return (
     <div className='w-full'>


### PR DESCRIPTION
### 📌 Description

- added hide logic for `Services Info Messages` in `_main._general.services.tsx`

---

### ✅ Actual (PR)

<img width="1298" height="595" alt="image" src="https://github.com/user-attachments/assets/921ef094-1574-4075-b759-66cba001972f" />

<img width="230" height="466" alt="image" src="https://github.com/user-attachments/assets/7317e7a3-cf9a-4c2e-94ed-3ffddbb3a4c6" />


---

### ❌ Before (App)

<img width="1258" height="251" alt="468046347-e407a5e3-c7ff-415d-8451-91ebc7847363" src="https://github.com/user-attachments/assets/fcc55629-b23b-45c7-9162-8117c9444635" />

<img width="1277" height="245" alt="468046517-0b0e1f5e-09a8-4049-b94d-a0454dac1b98" src="https://github.com/user-attachments/assets/5770a1f4-b48d-4cb0-b0b8-791e5449a042" />

<img width="1259" height="239" alt="468046604-53740bcb-094d-44ec-9503-9ab8072323c0" src="https://github.com/user-attachments/assets/739f0f03-cdab-4e54-a5a3-d18163ce2c92" />


