### PR TITLE
removed collapse logic in detail page

### DIFF
--- a/app/routes/_main._general._id.avatars.$id.tsx
+++ b/app/routes/_main._general._id.avatars.$id.tsx
@@ -51,7 +51,6 @@ export default function AvatarShow({ loaderData }: Route.ComponentProps) {
   const me = useRouteLoaderData('routes/_main') as User;
   // const fetcher = useFetcher();
   // const [copied, setCopied] = useState(false);
-  const [showAll, setShowAll] = useState(false);
   const copyTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   const scenarios = avatar.scenarios ? avatar.scenarios : [];
@@ -75,10 +74,6 @@ export default function AvatarShow({ loaderData }: Route.ComponentProps) {
   //   const timeoutId = setTimeout(() => setCopied(false), 2000);
   //   copyTimeoutRef.current = timeoutId;
   // };
-
-  const handleShowAll = () => {
-    setShowAll(!showAll);
-  };
 
   const getTextAfterThe = (text: string): string => {
     const words = text.split(' ');
@@ -197,7 +192,7 @@ export default function AvatarShow({ loaderData }: Route.ComponentProps) {
                 <div className='flex flex-col gap-5'>
                   <div className='grid grid-cols-1 sm:grid-cols-2 md:grid-cols-1 lg:grid-cols-2 gap-2'>
                     {sortedScenarios.map((scenario, index) => (
-                      <div className={`${!showAll && index >= 4 ? 'hidden' : 'transition-all duration-500 ease-out'}`} key={index}>
+                      <div className={'transition-all duration-500 ease-out'} key={index}>
                         <div className='flex flex-col bg-white shadow-bottom-level-1 rounded-xl overflow-hidden'>
                           <Link
                             to={`/scenarios/${scenario.id}`}
@@ -246,17 +241,6 @@ export default function AvatarShow({ loaderData }: Route.ComponentProps) {
                       </div>
                     ))}
                   </div>
-                  {scenarios.length > 4 && (
-                    <div className='mx-auto -mt-2'>
-                      <Button.Root variant='secondary' className='px-4 h-10 gap-2' onClick={handleShowAll}>
-                        {showAll ? 'Collapse' : 'Show all'}
-                        <Button.Icon
-                          as={Icons.chevronDown}
-                          className={`size-6 transition-transform duration-300 ${showAll ? 'rotate-180' : ''}`}
-                        />
-                      </Button.Root>
-                    </div>
-                  )}
                 </div>
               ) : (
                 <div className='bg-gradient-1 rounded-xl py-6 sm:py-4 px-6 flex sm:flex-col flex-row items-center sm:justify-center sm:gap-2 gap-6 col-span-2'>

--- a/app/routes/_main._general._id.scenarios.$scenariosId.tsx
+++ b/app/routes/_main._general._id.scenarios.$scenariosId.tsx
@@ -176,7 +176,7 @@ export default function ScenariosId({ loaderData }: Route.ComponentProps) {
                 <div className='flex flex-col gap-5'>
                   <div className='grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-1 lg:grid-cols-2'>
                     {avatars.map((avatar, index) => (
-                      <div className={`${!showAll && index >= 4 ? 'hidden' : 'transition-all duration-500 ease-out'}`} key={index}>
+                      <div className={'transition-all duration-500 ease-out'} key={index}>
                         <div className='flex flex-col bg-white shadow-bottom-level-1 rounded-xl overflow-hidden'>
                           <Link
                             to={`/scenarios/${scenario.id}`}
@@ -227,17 +227,6 @@ export default function ScenariosId({ loaderData }: Route.ComponentProps) {
                       </div>
                     ))}
                   </div>
-                  {avatars.length > 4 && (
-                    <div className='mx-auto -mt-2'>
-                      <Button.Root variant='secondary' className='px-4 h-10 gap-2' onClick={handleShowAll}>
-                        {showAll ? 'Collapse' : 'Show all'}
-                        <Button.Icon
-                          as={Icons.chevronDown}
-                          className={`size-6 transition-transform duration-300 ${showAll ? 'rotate-180' : ''}`}
-                        />
-                      </Button.Root>
-                    </div>
-                  )}
                 </div>
               ) : (
                 <div className='bg-gradient-1 rounded-xl py-6 sm:py-4 px-6 flex sm:flex-col flex-row items-center sm:justify-center sm:gap-2 gap-6 col-span-2'>


### PR DESCRIPTION
### 📌 Description

- removed collapse logic and button in `_main._general._id.avatars.$id.tsx` & `_main._general._id.scenarios.$scenariosId.tsx`

---

### ✅ Actual (PR)

<img width="689" height="634" alt="image" src="https://github.com/user-attachments/assets/c8035a77-1f16-4431-ac0e-b0ca7b96a067" />

<img width="668" height="632" alt="image" src="https://github.com/user-attachments/assets/02b47c21-027a-4ebe-a169-439636a2805f" />

---

### ❌ Before (App)

<img width="1354" height="912" alt="image" src="https://github.com/user-attachments/assets/963a04c0-77b1-496f-a156-77a7c96928a2" />

<img width="1364" height="952" alt="image" src="https://github.com/user-attachments/assets/44266a16-2dbe-464d-af04-bf42dc45c88f" />

