### PR TITLE
signout button is moved to the account bottomright

### DIFF
--- a/app/components/sidebar.tsx
+++ b/app/components/sidebar.tsx
@@ -1,6 +1,6 @@
 import { Link, NavLink } from 'react-router';
 import { useMemo, useCallback } from 'react';
-import { Icons } from './ui/icons';
+import { Icons, type IconProps } from './ui/icons';
 import { cn } from '~/utils/cn';
 import SignOutModal from './signOutModal';
 import { ViewMore } from '~/view-more';
@@ -29,11 +29,6 @@ const SidebarItems = [
     href: ROUTES.services,
     icon: Icons.services,
     hideOnMobile: true,
-  },
-  {
-    name: 'Account',
-    href: ROUTES.account,
-    icon: Icons.account,
   },
   // {
   //   name: 'Hardware',
@@ -68,7 +63,7 @@ const Sidebar = ({ className }: { className?: string }) => {
   );
 
   const getNavLinkClassName = useCallback(
-    (item: (typeof SidebarItems)[0]) =>
+    (item: { name: string; href: string | null; icon: (props: IconProps) => React.JSX.Element; hideOnMobile?: boolean; showOnMobileOnly?: boolean }) =>
       ({ isActive }: { isActive: boolean }) => {
         return cn(
           'sm:py-3 py-2 sm:px-0 px-2 transition-colors rounded-xl flex flex-col sm:gap-2 gap-1 sm:w-full items-center justify-center',
@@ -126,14 +121,18 @@ const Sidebar = ({ className }: { className?: string }) => {
             );
           })}
         </div>
-        <div className='sm:block hidden w-full'>
+        <NavLink to={ROUTES.account} className={getNavLinkClassName({ name: 'Account', href: ROUTES.account, icon: Icons.account })}>
+          {<Icons.account />}
+          <span className='text-label font-semibold'>Account</span>
+        </NavLink>
+        {/* <div className='sm:block hidden w-full'>
           <SignOutModal>
             <button className='py-3 transition-colors text-label font-semibold text-pink-01 flex items-center justify-center gap-2 flex-col rounded-xl w-full bg-transparent hover:bg-neutral-05'>
               <Icons.signOut className='fill-[#350D2A]/40' />
               Sign Out
             </button>
           </SignOutModal>
-        </div>
+        </div> */}
         {/* Optional for now */}
         {/* <div className="h-[34px] w-full sm:hidden" /> */}
       </div>

--- a/app/routes/_main._general.account.tsx
+++ b/app/routes/_main._general.account.tsx
@@ -10,14 +10,16 @@ import TokenPermitsList from '~/components/TokenPermitsList';
 import { useNetworkCheck } from '~/hooks/useNetworkCheck';
 import NetworkWarningBanner from '~/components/NetworkWarningBanner';
 import { YourReferrals } from '~/components/your-referrals';
-import { useUser } from '~/hooks/queries/userQueries';
+
+import SignOutModal from '~/components/signOutModal';
+import * as Button from '~/components/ui/button/button';
 
 export function meta({}: Route.MetaArgs) {
   return [
     { title: 'Account' },
     { name: 'description', content: 'Manage your avatars, scenarios and chats from your personal account' },
     { name: 'robots', content: 'noindex, nofollow' },
-    { name: 'viewport', content: 'width=device-width, initial-scale=1' }
+    { name: 'viewport', content: 'width=device-width, initial-scale=1' },
   ];
 }
 
@@ -52,6 +54,12 @@ export default function Account() {
           <TokenBalance />
           <TokenPermitsList />
           <YourReferrals />
+          <SignOutModal>
+            <Button.Root variant='primary' className='w-full'>
+              <Icons.signOut className='fill-[#350D2A]/40' />
+              Sign Out
+            </Button.Root>
+          </SignOutModal>
         </div>
       </div>
       <Outlet />


### PR DESCRIPTION
@ffaerber I have moved the signout button to the account page as you wish but I have noticed that users can only signout from account route now. Is that ok for you? or do we need to think about different solution

<img width="1135" height="1176" alt="Screenshot 2025-09-30 at 06 35 23" src="https://github.com/user-attachments/assets/4f914727-e287-4cb7-84d6-1b74fbc79a2d" />
